### PR TITLE
Refactor : 모임 참가자 리스트 조회 기능 Participant domain으로 분리

### DIFF
--- a/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,25 @@
+package com.sosim.server.common.resolver;
+
+import com.sosim.server.security.AuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean existAuthUserIdAnnotation = parameter.getParameterAnnotation(AuthUserId.class) != null;
+        boolean isUserIdClass = long.class.equals(parameter.getParameterType()) || Long.class.equals(parameter.getParameterType());
+
+        return existAuthUserIdAnnotation && isUserIdClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        AuthUser authUser = (AuthUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return authUser.getId();
+    }
+}

--- a/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
@@ -3,11 +3,13 @@ package com.sosim.server.common.resolver;
 import com.sosim.server.security.AuthUser;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -20,6 +22,6 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         AuthUser authUser = (AuthUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return authUser.getId();
+        return authUser.getId() == null ? 0L : authUser.getId();
     }
 }

--- a/src/main/java/com/sosim/server/common/resolver/AuthUserId.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserId.java
@@ -1,0 +1,11 @@
+package com.sosim.server.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUserId {
+}

--- a/src/main/java/com/sosim/server/config/WebMvcConfig.java
+++ b/src/main/java/com/sosim/server/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.sosim.server.config;
+
+import com.sosim.server.common.resolver.AuthUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/sosim/server/group/Group.java
+++ b/src/main/java/com/sosim/server/group/Group.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "GROUP")
+@Table(name = "GROUPS")
 public class Group extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/group/GroupController.java
+++ b/src/main/java/com/sosim/server/group/GroupController.java
@@ -41,16 +41,15 @@ public class GroupController {
     }
 
     @GetMapping("/group/{groupId}")
-    public ResponseEntity<?> getGroup(@AuthUserId long userId, @PathVariable("groupId") Long groupId) {
+    public ResponseEntity<?> getGroup(@AuthUserId long userId, @PathVariable("groupId") long groupId) {
         GetGroupResponse getGroupResponse = groupService.getGroup(userId, groupId);
         ResponseCode getGroup = ResponseCode.GET_GROUP;
 
         return new ResponseEntity<>(Response.create(getGroup, getGroupResponse), getGroup.getHttpStatus());
     }
 
-    @GetMapping("/group/{groupId}/participants")
-    public ResponseEntity<?> getGroupParticipants(@AuthenticationPrincipal AuthUser authUser,
-                                                  @PathVariable("groupId") Long groupId) {
+//    @GetMapping("/group/{groupId}/participants")
+    public ResponseEntity<?> getGroupParticipants(@AuthenticationPrincipal AuthUser authUser, @PathVariable("groupId") long groupId) {
         GetParticipantListResponse getGroupParticipants = groupService.getGroupParticipants(authUser.getId(), groupId);
         ResponseCode getParticipants = ResponseCode.GET_PARTICIPANTS;
 
@@ -59,7 +58,7 @@ public class GroupController {
 
     @PatchMapping("/group/{groupId}")
     public ResponseEntity<?> modifyGroup(@AuthUserId long userId,
-                                         @PathVariable("groupId") Long groupId,
+                                         @PathVariable("groupId") long groupId,
                                          @Validated @RequestBody UpdateGroupRequest updateGroupRequest,
                                          BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
@@ -74,7 +73,7 @@ public class GroupController {
 
     @DeleteMapping("/group/{groupId}")
     public ResponseEntity<?> deleteGroup(@AuthUserId long userId,
-                                         @PathVariable("groupId") Long groupId) {
+                                         @PathVariable("groupId") long groupId) {
         groupService.deleteGroup(userId, groupId);
         ResponseCode deleteGroup = ResponseCode.DELETE_GROUP;
 
@@ -83,7 +82,7 @@ public class GroupController {
 
     @PostMapping("/group/{groupId}/participant")
     public ResponseEntity<?> intoGroup(@AuthenticationPrincipal AuthUser authUser,
-                                       @PathVariable("groupId") Long groupId,
+                                       @PathVariable("groupId") long groupId,
                                        @Validated @RequestBody ParticipantNicknameRequest participantNicknameRequest,
                                        BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
@@ -98,7 +97,7 @@ public class GroupController {
 
     @PatchMapping("/group/{groupId}/admin")
     public ResponseEntity<?> modifyAdmin(@AuthenticationPrincipal AuthUser authUser,
-                                         @PathVariable("groupId") Long groupId,
+                                         @PathVariable("groupId") long groupId,
                                          @RequestBody ParticipantNicknameRequest participantNicknameRequest) {
 
         groupService.modifyAdmin(authUser.getId(), groupId, participantNicknameRequest);
@@ -109,7 +108,7 @@ public class GroupController {
 
     @DeleteMapping("/group/{groupId}/participant")
     public ResponseEntity<?> withdrawGroup(@AuthenticationPrincipal AuthUser authUser,
-                                           @PathVariable("groupId") Long groupId) {
+                                           @PathVariable("groupId") long groupId) {
         groupService.withdrawGroup(authUser.getId(), groupId);
         ResponseCode withdrawGroup = ResponseCode.WITHDRAW_GROUP;
 
@@ -118,7 +117,7 @@ public class GroupController {
 
     @PatchMapping("/group/{groupId}/participant")
     public ResponseEntity<?> modifyNickname(@AuthenticationPrincipal AuthUser authUser,
-                                            @PathVariable ("groupId") Long groupId,
+                                            @PathVariable ("groupId") long groupId,
                                             @Validated @RequestBody ParticipantNicknameRequest participantNicknameRequest) {
         groupService.modifyNickname(authUser.getId(), groupId, participantNicknameRequest);
         ResponseCode modifyNickname = ResponseCode.MODIFY_NICKNAME;
@@ -141,7 +140,7 @@ public class GroupController {
 
     @GetMapping("/group/{groupId}/participant")
     public ResponseEntity<?> getMyNickname(@AuthenticationPrincipal AuthUser authUser,
-                                           @PathVariable("groupId") Long groupId) {
+                                           @PathVariable("groupId") long groupId) {
         GetNicknameResponse getNicknameResponse = groupService.getMyNickname(authUser.getId(), groupId);
         ResponseCode getNickname = ResponseCode.GET_NICKNAME;
 

--- a/src/main/java/com/sosim/server/group/GroupController.java
+++ b/src/main/java/com/sosim/server/group/GroupController.java
@@ -11,7 +11,6 @@ import com.sosim.server.group.dto.response.GetGroupResponse;
 import com.sosim.server.group.dto.response.GroupIdResponse;
 import com.sosim.server.participant.dto.request.ParticipantNicknameRequest;
 import com.sosim.server.participant.dto.response.GetNicknameResponse;
-import com.sosim.server.participant.dto.response.GetParticipantListResponse;
 import com.sosim.server.security.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -46,14 +45,6 @@ public class GroupController {
         ResponseCode getGroup = ResponseCode.GET_GROUP;
 
         return new ResponseEntity<>(Response.create(getGroup, getGroupResponse), getGroup.getHttpStatus());
-    }
-
-//    @GetMapping("/group/{groupId}/participants")
-    public ResponseEntity<?> getGroupParticipants(@AuthenticationPrincipal AuthUser authUser, @PathVariable("groupId") long groupId) {
-        GetParticipantListResponse getGroupParticipants = groupService.getGroupParticipants(authUser.getId(), groupId);
-        ResponseCode getParticipants = ResponseCode.GET_PARTICIPANTS;
-
-        return new ResponseEntity<>(Response.create(getParticipants, getGroupParticipants), getParticipants.getHttpStatus());
     }
 
     @PatchMapping("/group/{groupId}")

--- a/src/main/java/com/sosim/server/group/GroupController.java
+++ b/src/main/java/com/sosim/server/group/GroupController.java
@@ -1,6 +1,7 @@
 package com.sosim.server.group;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.resolver.AuthUserId;
 import com.sosim.server.common.response.Response;
 import com.sosim.server.common.response.ResponseCode;
 import com.sosim.server.group.dto.request.CreateGroupRequest;
@@ -27,24 +28,21 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping("/group")
-    public ResponseEntity<?> createGroup(@AuthenticationPrincipal AuthUser authUser,
-                                         @Validated @RequestBody CreateGroupRequest createGroupRequest,
+    public ResponseEntity<?> createGroup(@AuthUserId long userId, @Validated @RequestBody CreateGroupRequest createGroupRequest,
                                          BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             bindingError(bindingResult);
         }
 
-        GroupIdResponse groupIdResponse = groupService.createGroup(authUser.getId(), createGroupRequest);
+        GroupIdResponse groupIdResponse = groupService.createGroup(userId, createGroupRequest);
         ResponseCode createGroup = ResponseCode.CREATE_GROUP;
 
         return new ResponseEntity<>(Response.create(createGroup, groupIdResponse), createGroup.getHttpStatus());
     }
 
     @GetMapping("/group/{groupId}")
-    public ResponseEntity<?> getGroup(@AuthenticationPrincipal AuthUser authUser,
-                                      @PathVariable("groupId") Long groupId) {
-        GetGroupResponse getGroupResponse = groupService.getGroup(
-                authUser != null ? authUser.getId() : 0, groupId);
+    public ResponseEntity<?> getGroup(@AuthUserId long userId, @PathVariable("groupId") Long groupId) {
+        GetGroupResponse getGroupResponse = groupService.getGroup(userId, groupId);
         ResponseCode getGroup = ResponseCode.GET_GROUP;
 
         return new ResponseEntity<>(Response.create(getGroup, getGroupResponse), getGroup.getHttpStatus());
@@ -60,7 +58,7 @@ public class GroupController {
     }
 
     @PatchMapping("/group/{groupId}")
-    public ResponseEntity<?> modifyGroup(@AuthenticationPrincipal AuthUser authUser,
+    public ResponseEntity<?> modifyGroup(@AuthUserId long userId,
                                          @PathVariable("groupId") Long groupId,
                                          @Validated @RequestBody UpdateGroupRequest updateGroupRequest,
                                          BindingResult bindingResult) {
@@ -68,16 +66,16 @@ public class GroupController {
             bindingError(bindingResult);
         }
 
-        GroupIdResponse groupIdResponse = groupService.updateGroup(authUser.getId(), groupId, updateGroupRequest);
+        GroupIdResponse groupIdResponse = groupService.updateGroup(userId, groupId, updateGroupRequest);
         ResponseCode modifyGroup = ResponseCode.MODIFY_GROUP;
 
         return new ResponseEntity<>(Response.create(modifyGroup, groupIdResponse), modifyGroup.getHttpStatus());
     }
 
     @DeleteMapping("/group/{groupId}")
-    public ResponseEntity<?> deleteGroup(@AuthenticationPrincipal AuthUser authUser,
+    public ResponseEntity<?> deleteGroup(@AuthUserId long userId,
                                          @PathVariable("groupId") Long groupId) {
-        groupService.deleteGroup(authUser.getId(), groupId);
+        groupService.deleteGroup(userId, groupId);
         ResponseCode deleteGroup = ResponseCode.DELETE_GROUP;
 
         return new ResponseEntity<>(Response.create(deleteGroup, null), deleteGroup.getHttpStatus());

--- a/src/main/java/com/sosim/server/group/GroupService.java
+++ b/src/main/java/com/sosim/server/group/GroupService.java
@@ -74,7 +74,7 @@ public class GroupService {
             Collections.sort(nicknameList.subList(1, nicknameList.size()));
         }
 
-        return GetParticipantListResponse.create(groupEntity, nicknameList);
+        return GetParticipantListResponse.toDto(groupEntity, nicknameList);
     }
 
     @Transactional

--- a/src/main/java/com/sosim/server/group/GroupService.java
+++ b/src/main/java/com/sosim/server/group/GroupService.java
@@ -12,7 +12,6 @@ import com.sosim.server.participant.Participant;
 import com.sosim.server.participant.ParticipantService;
 import com.sosim.server.participant.dto.request.ParticipantNicknameRequest;
 import com.sosim.server.participant.dto.response.GetNicknameResponse;
-import com.sosim.server.participant.dto.response.GetParticipantListResponse;
 import com.sosim.server.user.User;
 import com.sosim.server.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -54,27 +51,6 @@ public class GroupService {
         return GetGroupResponse.create(groupEntity, groupEntity.getAdminId().equals(userId),
                 (int) groupEntity.getParticipantList().stream()
                         .filter(p -> p.getStatus().equals(Status.ACTIVE)).count(), isInto);
-    }
-
-    public GetParticipantListResponse getGroupParticipants(Long userId, Long groupId) {
-        Group groupEntity = getGroupEntity(groupId);
-        List<String> nicknameList = groupEntity.getParticipantList().stream()
-                .filter(p -> p.getStatus().equals(Status.ACTIVE) &&
-                        !p.getNickname().equals(groupEntity.getAdminNickname()))
-                .map(Participant::getNickname)
-                .collect(Collectors.toList());
-
-        if (!groupEntity.getAdminId().equals(userId)) {
-            String nickname = participantService.getParticipantEntity(
-                    userId, groupId).getNickname();
-            Collections.swap(nicknameList, 0, nicknameList.indexOf(nickname));
-        }
-
-        if (nicknameList.size() > 0) {
-            Collections.sort(nicknameList.subList(1, nicknameList.size()));
-        }
-
-        return GetParticipantListResponse.toDto(groupEntity, nicknameList);
     }
 
     @Transactional

--- a/src/main/java/com/sosim/server/participant/Participant.java
+++ b/src/main/java/com/sosim/server/participant/Participant.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "PARTICIPANT")
+@Table(name = "PARTICIPANTS")
 public class Participant extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/participant/ParticipantController.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantController.java
@@ -1,0 +1,81 @@
+package com.sosim.server.participant;
+
+import com.sosim.server.common.resolver.AuthUserId;
+import com.sosim.server.common.response.Response;
+import com.sosim.server.participant.dto.response.GetParticipantListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.sosim.server.common.response.ResponseCode.GET_PARTICIPANTS;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/group/{groupId}")
+public class ParticipantController {
+    private final ParticipantService participantService;
+
+    @GetMapping("/participants")
+    public ResponseEntity<?> getGroupParticipants(@AuthUserId long userId, @PathVariable("groupId") long groupId) {
+        GetParticipantListResponse getGroupParticipants = participantService.getGroupParticipants(userId, groupId);
+
+        return new ResponseEntity<>(Response.create(GET_PARTICIPANTS, getGroupParticipants), GET_PARTICIPANTS.getHttpStatus());
+    }
+
+//    @PostMapping("/participant")
+//    public ResponseEntity<?> intoGroup(@AuthUserId long userId,
+//                                       @PathVariable("groupId") long groupId,
+//                                       @Validated @RequestBody ParticipantNicknameRequest participantNicknameRequest,
+//                                       BindingResult bindingResult) {
+//        if (bindingResult.hasErrors()) {
+//            bindingError(bindingResult);
+//        }
+//
+//        groupService.intoGroup(userId, groupId, participantNicknameRequest);
+//        ResponseCode intoGroup = ResponseCode.INTO_GROUP;
+//
+//        return new ResponseEntity<>(Response.create(intoGroup, null), intoGroup.getHttpStatus());
+//    }
+
+//    @PatchMapping("/admin")
+//    public ResponseEntity<?> modifyAdmin(@AuthUserId long userId,
+//                                         @PathVariable("groupId") long groupId,
+//                                         @RequestBody ParticipantNicknameRequest participantNicknameRequest) {
+//
+//        groupService.modifyAdmin(userId, groupId, participantNicknameRequest);
+//        ResponseCode modifyGroupAdmin = ResponseCode.MODIFY_GROUP_ADMIN;
+//
+//        return new ResponseEntity<>(Response.create(modifyGroupAdmin, null), modifyGroupAdmin.getHttpStatus());
+//    }
+//
+//    @DeleteMapping("/participant")
+//    public ResponseEntity<?> withdrawGroup(@AuthUserId long userId,
+//                                           @PathVariable("groupId") long groupId) {
+//        groupService.withdrawGroup(userId, groupId);
+//        ResponseCode withdrawGroup = ResponseCode.WITHDRAW_GROUP;
+//
+//        return new ResponseEntity<>(Response.create(withdrawGroup, null), withdrawGroup.getHttpStatus());
+//    }
+//
+//    @PatchMapping("/participant")
+//    public ResponseEntity<?> modifyNickname(@AuthUserId long userId,
+//                                            @PathVariable ("groupId") long groupId,
+//                                            @Validated @RequestBody ParticipantNicknameRequest participantNicknameRequest) {
+//        groupService.modifyNickname(userId, groupId, participantNicknameRequest);
+//        ResponseCode modifyNickname = ResponseCode.MODIFY_NICKNAME;
+//
+//        return new ResponseEntity<>(Response.create(modifyNickname, null), modifyNickname.getHttpStatus());
+//    }
+//
+//    @GetMapping("/participant")
+//    public ResponseEntity<?> getMyNickname(@AuthUserId long userId,
+//                                           @PathVariable("groupId") long groupId) {
+//        GetNicknameResponse getNicknameResponse = groupService.getMyNickname(userId, groupId);
+//        ResponseCode getNickname = ResponseCode.GET_NICKNAME;
+//
+//        return new ResponseEntity<>(Response.create(getNickname, getNicknameResponse), getNickname.getHttpStatus());
+//    }
+}

--- a/src/main/java/com/sosim/server/participant/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantRepository.java
@@ -31,9 +31,9 @@ public interface ParticipantRepository extends JpaRepository<Participant, java.l
    Slice<Participant> findByIdLessThanAndUserIdOrderByIdDesc(@Param("participantId")Long participantId, @Param("userId")Long userId, Pageable pageable);
 
     @Query("SELECT p FROM Participant p " +
-            "WHERE p.groupId = :groupId " +
+            "WHERE p.group.id = :groupId " +
             "AND p.nickname != :adminNickname " +
-            "AND p.status = 'ACTIVE " +
+            "AND p.status = 'ACTIVE' " +
             "ORDER BY p.nickname ASC")
     List<Participant> findGroupNormalParticipants(@Param("groupId") long groupId, @Param("adminNickname") String adminNickname);
 }

--- a/src/main/java/com/sosim/server/participant/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, java.lang.Long> {
@@ -28,4 +29,11 @@ public interface ParticipantRepository extends JpaRepository<Participant, java.l
    @Query("select p from Participant p where p.id < :participantId " +
            "and p.user.id = :userId and p.status = 'ACTIVE' order by p.id desc")
    Slice<Participant> findByIdLessThanAndUserIdOrderByIdDesc(@Param("participantId")Long participantId, @Param("userId")Long userId, Pageable pageable);
+
+    @Query("SELECT p FROM Participant p " +
+            "WHERE p.groupId = :groupId " +
+            "AND p.nickname != :adminNickname " +
+            "AND p.status = 'ACTIVE " +
+            "ORDER BY p.nickname ASC")
+    List<Participant> findGroupNormalParticipants(@Param("groupId") long groupId, @Param("adminNickname") String adminNickname);
 }

--- a/src/main/java/com/sosim/server/participant/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantService.java
@@ -4,8 +4,10 @@ import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.common.auditing.Status;
 import com.sosim.server.common.response.ResponseCode;
 import com.sosim.server.group.Group;
+import com.sosim.server.group.GroupRepository;
 import com.sosim.server.participant.dto.request.ParticipantNicknameRequest;
 import com.sosim.server.participant.dto.response.GetNicknameResponse;
+import com.sosim.server.participant.dto.response.GetParticipantListResponse;
 import com.sosim.server.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -13,11 +15,18 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.sosim.server.common.response.ResponseCode.NONE_PARTICIPANT;
+import static com.sosim.server.common.response.ResponseCode.NOT_FOUND_GROUP;
+
 @Service
 @RequiredArgsConstructor
 public class ParticipantService {
 
     private final ParticipantRepository participantRepository;
+    private final GroupRepository groupRepository;
 
     public void creteParticipant(User user, Group group, String nickname) {
         if (participantRepository.existsByUserIdAndGroupIdAndStatus(user.getId(), group.getId(), Status.ACTIVE)) {
@@ -29,6 +38,50 @@ public class ParticipantService {
         }
 
         saveParticipantEntity(Participant.create(user, group, nickname));
+    }
+
+    public GetParticipantListResponse getGroupParticipants(long userId, long groupId) {
+        Group group = getGroupEntity(groupId);
+        List<Participant> normalParticipants = participantRepository.findGroupNormalParticipants(groupId, group.getAdminNickname());
+        if (isNotAdminUser(userId, group)) {
+            changeUserToFirstOrder(userId, normalParticipants);
+        }
+        return GetParticipantListResponse.toDto(group, toNicknameList(normalParticipants));
+    }
+
+    private static List<String> toNicknameList(List<Participant> normalParticipants) {
+        return normalParticipants.stream()
+                .map(Participant::getNickname)
+                .collect(Collectors.toList());
+    }
+
+    private void changeUserToFirstOrder(long userId, List<Participant> participants) {
+        int index = getParticipantIndexOfUser(userId, participants);
+        Participant participantOfUser = participants.remove(index);
+        participants.add(0, participantOfUser);
+    }
+
+    private int getParticipantIndexOfUser(long userId, List<Participant> participants) {
+        for (int i = 0; i < participants.size(); i++) {
+            Participant participant = participants.get(i);
+            if (isParticipantOfUser(userId, participant)) {
+                return i;
+            }
+        }
+        throw new CustomException(NONE_PARTICIPANT);
+    }
+
+    private boolean isParticipantOfUser(long userId, Participant participant) {
+        return participant.getUser().getId().equals(userId);
+    }
+
+    private boolean isNotAdminUser(long userId, Group group) {
+        return !group.getAdminId().equals(userId);
+    }
+
+    private Group getGroupEntity(long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
 
     @Transactional

--- a/src/main/java/com/sosim/server/participant/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantService.java
@@ -40,11 +40,12 @@ public class ParticipantService {
         saveParticipantEntity(Participant.create(user, group, nickname));
     }
 
+    @Transactional(readOnly = true)
     public GetParticipantListResponse getGroupParticipants(long userId, long groupId) {
         Group group = getGroupEntity(groupId);
         List<Participant> normalParticipants = participantRepository.findGroupNormalParticipants(groupId, group.getAdminNickname());
-        if (isNotAdminUser(userId, group)) {
-            changeUserToFirstOrder(userId, normalParticipants);
+        if (requestUserIsNotAdmin(userId, group)) {
+            changeRequestUserOrderToFirst(userId, normalParticipants);
         }
         return GetParticipantListResponse.toDto(group, toNicknameList(normalParticipants));
     }
@@ -55,7 +56,7 @@ public class ParticipantService {
                 .collect(Collectors.toList());
     }
 
-    private void changeUserToFirstOrder(long userId, List<Participant> participants) {
+    private void changeRequestUserOrderToFirst(long userId, List<Participant> participants) {
         int index = getParticipantIndexOfUser(userId, participants);
         Participant participantOfUser = participants.remove(index);
         participants.add(0, participantOfUser);
@@ -75,7 +76,7 @@ public class ParticipantService {
         return participant.getUser().getId().equals(userId);
     }
 
-    private boolean isNotAdminUser(long userId, Group group) {
+    private boolean requestUserIsNotAdmin(long userId, Group group) {
         return !group.getAdminId().equals(userId);
     }
 

--- a/src/main/java/com/sosim/server/participant/dto/response/GetParticipantListResponse.java
+++ b/src/main/java/com/sosim/server/participant/dto/response/GetParticipantListResponse.java
@@ -1,23 +1,19 @@
 package com.sosim.server.participant.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sosim.server.group.Group;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 public class GetParticipantListResponse {
-    @JsonProperty("adminNickname")
     private String adminNickname;
 
-    @JsonProperty("memberList")
     private List<String> nicknameList;
 
-    public static GetParticipantListResponse create(Group group, List<String> nicknameList) {
+    public static GetParticipantListResponse toDto(Group group, List<String> nicknameList) {
         return GetParticipantListResponse.builder()
                 .adminNickname(group.getAdminNickname())
                 .nicknameList(nicknameList)

--- a/src/main/java/com/sosim/server/user/User.java
+++ b/src/main/java/com/sosim/server/user/User.java
@@ -4,7 +4,6 @@ import com.sosim.server.common.auditing.BaseTimeEntity;
 import com.sosim.server.common.auditing.Status;
 import com.sosim.server.oauth.Social;
 import com.sosim.server.oauth.dto.request.OAuthUserRequest;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +13,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "USER")
+@Table(name = "USERS")
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +33,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "WITHDRAW_REASON")
     private String withdrawReason;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private User(String email, Social social, Long socialId) {
         this.email = email;
         this.social = social;

--- a/src/test/java/com/sosim/server/participant/ParticipantControllerTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantControllerTest.java
@@ -1,0 +1,119 @@
+package com.sosim.server.participant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.participant.dto.response.GetParticipantListResponse;
+import com.sosim.server.security.WithMockCustomUser;
+import com.sosim.server.security.WithMockCustomUserSecurityContextFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static com.sosim.server.common.response.ResponseCode.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {ParticipantController.class})
+class ParticipantControllerTest {
+
+    static final String URI_PREFIX = "/api/group";
+    private Long userId = WithMockCustomUserSecurityContextFactory.USER_ID;
+    private long groupId = 1L;
+
+    @MockBean
+    @Autowired
+    ParticipantService participantService;
+
+    MockMvc mvc;
+
+    @Autowired
+    WebApplicationContext was;
+
+    ObjectMapper om;
+
+    @BeforeEach
+    public void init() {
+        mvc = MockMvcBuilders.webAppContextSetup(was).build();
+        om = new ObjectMapper();
+    }
+
+    @WithMockCustomUser
+    @DisplayName("모임 참가자 리스트 조회 / 성공")
+    @Test
+    void get_participants() throws Exception {
+        //given
+        String adminNickname = "총무닉네임";
+        GetParticipantListResponse response = makeGetParticipantsResponse(adminNickname);
+
+        doReturn(response).when(participantService).getGroupParticipants(userId, groupId);
+
+        //when
+        String url = URI_PREFIX.concat(String.format("/%d/participants", groupId));
+        ResultActions resultActions = mvc.perform(get(url));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status.code").value(GET_PARTICIPANTS.getCode()))
+                .andExpect(jsonPath("$.content.adminNickname").value(adminNickname))
+                .andExpect(jsonPath("$.content.nicknameList[0]").value("유저1"));
+
+        verify(participantService, times(1)).getGroupParticipants(userId, groupId);
+    }
+
+    @WithMockCustomUser
+    @DisplayName("모임 참가자 리스트 조회 / 그룹이 없는 경우")
+    @Test
+    void get_participants_no_group() throws Exception {
+        //given
+        CustomException e = new CustomException(NOT_FOUND_GROUP);
+        doThrow(e).when(participantService).getGroupParticipants(userId, groupId);
+
+        //when
+        String url = URI_PREFIX.concat(String.format("/%d/participants", groupId));
+        ResultActions resultActions = mvc.perform(get(url));
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status.code").value(NOT_FOUND_GROUP.getCode()))
+                .andExpect(jsonPath("$.status.message").value(NOT_FOUND_GROUP.getMessage()))
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @WithMockCustomUser
+    @DisplayName("모임 참가자 리스트 조회 / 요청한 유저의 Participant 정보가 없는 경우")
+    @Test
+    void get_participants_no_participant() throws Exception {
+        //given
+        CustomException e = new CustomException(NONE_PARTICIPANT);
+        doThrow(e).when(participantService).getGroupParticipants(userId, groupId);
+
+        //when
+        String url = URI_PREFIX.concat(String.format("/%d/participants", groupId));
+        ResultActions resultActions = mvc.perform(get(url));
+
+        //then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status.code").value(NONE_PARTICIPANT.getCode()))
+                .andExpect(jsonPath("$.status.message").value(NONE_PARTICIPANT.getMessage()))
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    private static GetParticipantListResponse makeGetParticipantsResponse(String adminNickname) {
+        return GetParticipantListResponse.builder()
+                .adminNickname(adminNickname)
+                .nicknameList(List.of("유저1", "유저2", "유저3"))
+                .build();
+    }
+
+}

--- a/src/test/java/com/sosim/server/participant/ParticipantRepositoryTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.sosim.server.participant;
+
+import com.sosim.server.group.Group;
+import com.sosim.server.group.GroupRepository;
+import com.sosim.server.user.User;
+import com.sosim.server.user.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class ParticipantRepositoryTest {
+
+    @Autowired
+    ParticipantRepository participantRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private long groupId;
+    private long userId;
+    private int nameNo;
+    private long adminId;
+    private String adminName;
+    private Participant admin;
+
+    @BeforeEach
+    void setUp() {
+        groupId = 1L;
+        userId = 1L;
+        nameNo = 10000;
+        admin = null;
+        adminId = 0;
+        adminName = "";
+    }
+
+    @Test
+    @DisplayName("findGroupNormalParticipants")
+    void findGroupNormalParticipants() throws Exception {
+        //given
+        int size = 4;
+        saveParticipantsInGroup(groupId, size);
+
+        //when
+        List<Participant> normalParticipants = participantRepository.findGroupNormalParticipants(groupId, adminName);
+
+        //then
+        assertThat(admin).isNotIn(normalParticipants);
+    }
+
+    private void saveParticipantsInGroup(long groupId, int size) {
+        Group group = makeGroup();
+        groupId = group.getId();
+        participantRepository.save(makeAdminParticipant(group, makeNickname()));
+        for (int i = 1; i < size; i++) {
+            participantRepository.save(makeParticipant(group, makeNickname()));
+        }
+    }
+
+    private String makeNickname() {
+        return String.format("닉네임%d", nameNo--);
+    }
+
+    private Group makeGroup() {
+        Group group = Group.builder().build();
+        return groupRepository.save(group);
+    }
+
+    private Participant makeAdminParticipant(Group group, String nickname) {
+        admin = makeParticipant(group, nickname);
+        group.modifyAdmin(admin);
+        groupRepository.save(group);
+        adminId = group.getAdminId();
+        adminName = group.getAdminNickname();
+        return admin;
+    }
+
+    private Participant makeParticipant(Group group, String nickname) {
+        User user = makeUser();
+        return Participant.create(user, group, nickname);
+    }
+
+    private User makeUser() {
+        User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId++);
+        return userRepository.save(user);
+    }
+}

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -1,0 +1,137 @@
+package com.sosim.server.participant;
+
+import com.sosim.server.group.Group;
+import com.sosim.server.group.GroupRepository;
+import com.sosim.server.group.dto.request.CreateGroupRequest;
+import com.sosim.server.group.dto.response.GroupIdResponse;
+import com.sosim.server.participant.dto.response.GetParticipantListResponse;
+import com.sosim.server.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantServiceTest {
+
+    private long userId = 1L;
+    private long groupId = 1L;
+
+    @InjectMocks
+    ParticipantService participantService;
+
+    @Mock
+    ParticipantRepository participantRepository;
+
+    @Mock
+    GroupRepository groupRepository;
+
+    @DisplayName("모임 참가자 리스트 조회 / 응답 테스트")
+    @Test
+    void get_participants() {
+        //given
+        String adminNickname = "총무닉네임";
+        Group group = new Group();
+        ReflectionTestUtils.setField(group, "id", groupId);
+        ReflectionTestUtils.setField(group, "adminId", userId);
+        ReflectionTestUtils.setField(group, "adminNickname", adminNickname);
+        List<Participant> participants = new ArrayList<>(List.of(
+                makeParticipant(userId + 1, "유저1"),
+                makeParticipant(userId + 2, "유저2")));
+
+        doReturn(Optional.of(group)).when(groupRepository).findById(groupId);
+        doReturn(participants).when(participantRepository).findGroupNormalParticipants(groupId, adminNickname);
+
+        //when
+        GetParticipantListResponse response = participantService.getGroupParticipants(userId, groupId);
+
+        //then
+        assertThat(response).isNotNull();
+        assertThat(response.getAdminNickname()).isEqualTo(adminNickname);
+        assertThat(response.getNicknameList()).containsExactly("유저1", "유저2");
+    }
+
+    @DisplayName("모임 참가자 리스트 조회 / 총무가 아닌 유저가 nicknameList의 첫 번째 원소")
+    @Test
+    void get_participants_not_admin_request() {
+        //given
+        String adminNickname = "총무닉네임";
+        long requestUserId = 9;
+        String requestUserName = "요청유저";
+
+        Group group = new Group();
+        ReflectionTestUtils.setField(group, "id", groupId);
+        ReflectionTestUtils.setField(group, "adminId", userId);
+        ReflectionTestUtils.setField(group, "adminNickname", adminNickname);
+        List<Participant> participants = new ArrayList<>(List.of(
+                makeParticipant(1, userId + 1, "유저1"),
+                makeParticipant(2, userId + 2, "유저2"),
+                makeParticipant(3, requestUserId, requestUserName)));
+
+        doReturn(Optional.of(group)).when(groupRepository).findById(groupId);
+        doReturn(participants).when(participantRepository).findGroupNormalParticipants(groupId, adminNickname);
+
+        //when
+        GetParticipantListResponse response = participantService.getGroupParticipants(requestUserId, groupId);
+
+        //then
+        assertThat(response.getNicknameList().get(0)).isEqualTo(requestUserName);
+    }
+
+    @DisplayName("모임 참가자 리스트 조회 / 요청 유저 제외하고 nickname 오름차순 정렬")
+    @Test
+    void get_participants_asc_nickname() {
+        //given
+        String adminNickname = "총무닉네임";
+        long requestUserId = 9;
+        String requestUserName = "3";
+
+        Group group = new Group();
+        ReflectionTestUtils.setField(group, "id", groupId);
+        ReflectionTestUtils.setField(group, "adminId", userId);
+        ReflectionTestUtils.setField(group, "adminNickname", adminNickname);
+        List<Participant> participants = new ArrayList<>(List.of(
+                makeParticipant(3, userId + 1, "1"),
+                makeParticipant(2, userId + 2, "2"),
+                makeParticipant(5, requestUserId, requestUserName),
+                makeParticipant(4, userId + 3, "4"),
+                makeParticipant(1, userId + 4, "5")));
+
+        doReturn(Optional.of(group)).when(groupRepository).findById(groupId);
+        doReturn(participants).when(participantRepository).findGroupNormalParticipants(groupId, adminNickname);
+
+        //when
+        GetParticipantListResponse response = participantService.getGroupParticipants(requestUserId, groupId);
+
+        //then
+        assertThat(response.getNicknameList())
+                .containsExactly(requestUserName, "1", "2", "4", "5");
+    }
+
+    private Participant makeParticipant(long id, String nickname) {
+        return makeParticipant(id, 0L, nickname);
+    }
+
+    private Participant makeParticipant(long id, long userId, String nickname) {
+        Participant participant = Participant.builder().nickname(nickname).build();
+        ReflectionTestUtils.setField(participant, "id", id);
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", userId);
+        ReflectionTestUtils.setField(participant, "user", user);
+        return participant;
+    }
+
+}


### PR DESCRIPTION
- 모임 참가자 리스트 조회 기능 분리
- Service 로직 리팩토링
- 각 layer별 단위 테스트 추가
- Security Session에 있는 AuthUser에서 userId 값을 추출하여 Controller에 바인딩해주는 ArgumentResolver 추가