### PR TITLE
Fix : 백틱(`) 사용 Group 테이블명 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/Group.java
+++ b/src/main/java/com/sosim/server/group/Group.java
@@ -20,7 +20,7 @@ import static com.sosim.server.common.response.ResponseCode.*;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "GROUPS")
+@Table(name = "`GROUPS`")
 public class Group extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 👀 개요
- Closes #28 
- Group Entity 테이블명 수정
<!--


- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- MySQL에서 GROUPS 예약어 처리
![image](https://github.com/so-sim/server/assets/123621015/597d9d4c-0f09-471a-ba25-8b4020caa9fa)

해당 예외 발생으로 백틱으로 테이블명을 묶어줘서 예약어와 충돌 발생 방지

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

