### PR TITLE
Fix: myGroups의 Participant fetch join 오류 문제 해결

### DIFF
--- a/src/main/java/com/sosim/server/group/GroupRepositoryImpl.java
+++ b/src/main/java/com/sosim/server/group/GroupRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.sosim.server.group;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sosim.server.participant.QParticipant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -20,9 +21,11 @@ public class GroupRepositoryImpl implements GroupRepositoryDsl {
 
     @Override
     public Slice<Group> findMyGroups(long userId, long offset, long limit) {
+        QParticipant participant2 = new QParticipant("participant2");
         List<Group> contents = jpaQueryFactory.selectFrom(group)
                 .join(group.participantList, participant).fetchJoin()
-                .where(participant.user.id.eq(userId),
+                .join(group.participantList, participant2)
+                .where(participant2.user.id.eq(userId), participant.status.eq(ACTIVE),
                         group.status.eq(ACTIVE))
                 .orderBy(group.id.desc())
                 .offset(offset)


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

- myGroups의 쿼리 수정
- 기존 : userId에 해당하는 Participant 데이터만 Group에 포함
- 수정 : 해당 Group의 모든 Participant를 Fetch Join해서 Group에 포함

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
