### PR TITLE
Fix : Event 필터링 TotalSize 로직 수정

### DIFF
--- a/src/main/java/com/sosim/server/event/EventRepositoryImpl.java
+++ b/src/main/java/com/sosim/server/event/EventRepositoryImpl.java
@@ -27,7 +27,8 @@ public class EventRepositoryImpl implements EventRepositoryDsl {
 
     @Override
     public Page<Event> searchAll(FilterEventRequest filterEventRequest, Pageable pageable) {
-        return doPageable(filterEvent(filterEventRequest), pageable);
+        JPAQuery<Event> filterEvent = filterEvent(filterEventRequest);
+        return doPageable(filterEvent, pageable, filterEvent.fetch().size());
     }
 
     private JPAQuery<Event> filterEvent(FilterEventRequest filterEventRequest) {
@@ -58,9 +59,9 @@ public class EventRepositoryImpl implements EventRepositoryDsl {
         return situation == null ? null : event.situation.contains(situation);
     }
 
-    private Page<Event> doPageable(JPAQuery<Event> filterEvents, Pageable pageable) {
+    private Page<Event> doPageable(JPAQuery<Event> filterEvents, Pageable pageable, long totalSize) {
         return new PageImpl<>(filterEvents.offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
-                        .fetch());
+                        .fetch(), pageable, totalSize);
     }
 }


### PR DESCRIPTION
## 👀 개요

- Closes #40 
- Pagination 후, getTotalElements 사용 시 Pagination 후의 사이즈 반환


<!--


- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- Pagination 작업 전 전체 요소 수를 먼저 구해두고 해당 고정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


