### PR TITLE
Feat : Event Situation 수정 시, 변경된 Situation 값 추가 Response

### DIFF
--- a/src/main/java/com/sosim/server/event/EventController.java
+++ b/src/main/java/com/sosim/server/event/EventController.java
@@ -7,10 +7,7 @@ import com.sosim.server.event.dto.request.CreateEventRequest;
 import com.sosim.server.event.dto.request.FilterEventRequest;
 import com.sosim.server.event.dto.request.ModifyEventRequest;
 import com.sosim.server.event.dto.request.ModifySituationRequest;
-import com.sosim.server.event.dto.response.EventIdResponse;
-import com.sosim.server.event.dto.response.GetEventCalendarResponse;
-import com.sosim.server.event.dto.response.GetEventListResponse;
-import com.sosim.server.event.dto.response.GetEventOneResponse;
+import com.sosim.server.event.dto.response.*;
 import com.sosim.server.security.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -65,10 +62,10 @@ public class EventController {
     @PatchMapping("/penalty")
     public ResponseEntity<?> modifyEventSituation(@AuthUserId long userId,
                                                   @Validated @RequestBody ModifySituationRequest modifySituationRequest) {
-        List<Long> eventIdListResponse = eventService.modifyEventSituation(userId, modifySituationRequest);
+        ModifySituationResponse modifySituationResponse = eventService.modifyEventSituation(userId, modifySituationRequest);
         ResponseCode modifySituation = ResponseCode.MODIFY_EVENT_SITUATION;
 
-        return new ResponseEntity<>(Response.create(modifySituation, eventIdListResponse), modifySituation.getHttpStatus());
+        return new ResponseEntity<>(Response.create(modifySituation, modifySituationResponse), modifySituation.getHttpStatus());
     }
 
     @GetMapping("/penalty/calendar")

--- a/src/main/java/com/sosim/server/event/EventRepositoryImpl.java
+++ b/src/main/java/com/sosim/server/event/EventRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.sosim.server.event;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.dto.request.FilterEventRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,9 +38,10 @@ public class EventRepositoryImpl implements EventRepositoryDsl {
                         equalsGroup(filterEventRequest.getGroupId()),
                         betweenTime(filterEventRequest.getStartDate(), filterEventRequest.getEndDate()),
                         equalsNickname(filterEventRequest.getNickname()),
-                        equalsSituation(filterEventRequest.getSituation())
+                        equalsSituation(filterEventRequest.getSituation()),
+                        event.status.eq(Status.ACTIVE)
                 )
-                .orderBy(event.date.asc());
+                .orderBy(event.date.asc(), event.id.asc());
     }
 
     private BooleanExpression equalsGroup(long groupId) {

--- a/src/main/java/com/sosim/server/event/EventService.java
+++ b/src/main/java/com/sosim/server/event/EventService.java
@@ -6,10 +6,7 @@ import com.sosim.server.event.dto.request.CreateEventRequest;
 import com.sosim.server.event.dto.request.FilterEventRequest;
 import com.sosim.server.event.dto.request.ModifyEventRequest;
 import com.sosim.server.event.dto.request.ModifySituationRequest;
-import com.sosim.server.event.dto.response.EventIdResponse;
-import com.sosim.server.event.dto.response.GetEventCalendarResponse;
-import com.sosim.server.event.dto.response.GetEventListResponse;
-import com.sosim.server.event.dto.response.GetEventOneResponse;
+import com.sosim.server.event.dto.response.*;
 import com.sosim.server.group.Group;
 import com.sosim.server.group.GroupRepository;
 import com.sosim.server.participant.Participant;
@@ -81,13 +78,13 @@ public class EventService {
     }
 
     @Transactional
-    public List<Long> modifyEventSituation(long userId, ModifySituationRequest modifySituationRequest) {
+    public ModifySituationResponse modifyEventSituation(long userId, ModifySituationRequest modifySituationRequest) {
         List<Event> eventList = eventRepository.findByIdIn(modifySituationRequest.getEventIdList());
         for (Event event : eventList) {
             event.modifySituation(modifySituationRequest.getSituation());
         }
 
-        return eventList.stream().map(Event::getId).collect(Collectors.toList());
+        return ModifySituationResponse.toDto(modifySituationRequest.getSituation(), eventList.stream().map(Event::getId).collect(Collectors.toList()));
     }
 
     public GetEventCalendarResponse getEventCalendar(FilterEventRequest filterEventRequest) {

--- a/src/main/java/com/sosim/server/event/dto/response/ModifySituationResponse.java
+++ b/src/main/java/com/sosim/server/event/dto/response/ModifySituationResponse.java
@@ -1,0 +1,22 @@
+package com.sosim.server.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ModifySituationResponse {
+
+    private String situation;
+
+    private List<Long> eventIdList;
+
+    public static ModifySituationResponse toDto(String situation, List<Long> eventIdList) {
+        return ModifySituationResponse.builder()
+                .situation(situation)
+                .eventIdList(eventIdList)
+                .build();
+    }
+}


### PR DESCRIPTION
## 👀 개요

- Closes #36 
- Closes #37 
- Event Situation 수정 시, 변경된 Situation 값 추가 (Front 요청 사항)
- Event 조회 시, 활성화(Active) 된 상태만 조회 하는게 아닌 삭제(Deleted) 된 상태까지 같이 조회하던 문제점

<!--

- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

- Event Situation(납부 여부) 상태 변경 시, 변경된 Situation(납부 여부) 같이 Response
- QueryDSL 에서 Event 조회 시, Status(상태 여부) 누락 조건문 추가

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->



<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->
