### PR TITLE
Feat : JWT Exception 처리

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -42,6 +42,8 @@ public enum ResponseCode {
     INCORRECT_OAUTH_CODE(1401, HttpStatus.BAD_REQUEST, "올바르지 않은 Authorization 코드입니다."),
 
     NOT_EXIST_TOKEN_COOKIE(1200, HttpStatus.BAD_REQUEST, "리프레시 토큰이 존재하지 않습니다."),
+    MODULATION_JWT(1201, HttpStatus.UNAUTHORIZED, "변조된 JWT 토큰 입니다."),
+    EXPIRATION_JWT(1202, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
 
     NOT_FOUND_USER(1100, HttpStatus.NOT_FOUND, "존재하지 않는 회원 정보입니다."),
     USER_ALREADY_EXIST(1101, HttpStatus.BAD_REQUEST, "이미 존재하는 회원 정보입니다."),

--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package com.sosim.server.config;
 
 import com.sosim.server.jwt.util.JwtProvider;
-import com.sosim.server.security.AuthenticationFilter;
+import com.sosim.server.security.filter.AuthenticationFilter;
+import com.sosim.server.security.filter.JwtFailureFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -38,7 +39,8 @@ public class SecurityConfig {
                 .antMatchers("/api/**").authenticated();
 
         http
-                .addFilterBefore(new AuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new AuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtFailureFilter(), AuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.sosim.server.security.filter.AuthenticationFilter;
 import com.sosim.server.security.filter.JwtFailureFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -35,8 +36,9 @@ public class SecurityConfig {
         // 요청에 대한 권한 체크 파트
         http
                 .authorizeRequests()
-                .antMatchers("/**", "/api/group/{groupId}").permitAll()
-                .antMatchers("/api/**").authenticated();
+                .antMatchers("/api/group/{groupId}").permitAll()
+                .antMatchers("/api/**").authenticated()
+                .antMatchers("/**").permitAll();
 
         http
                 .addFilterBefore(new AuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/sosim/server/jwt/util/JwtProvider.java
+++ b/src/main/java/com/sosim/server/jwt/util/JwtProvider.java
@@ -1,7 +1,8 @@
 package com.sosim.server.jwt.util;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
+import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.response.ResponseCode;
+import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -28,10 +29,16 @@ public class JwtProvider {
         return Long.valueOf(getClaims(accessKey, accessToken).getSubject());
     }
 
-    private Claims getClaims(String key, String token){
-        return Jwts.parser()
-                .setSigningKey(key.getBytes(StandardCharsets.UTF_8))
-                .parseClaimsJws(token)
-                .getBody();
+    private Claims getClaims(String key, String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(key.getBytes(StandardCharsets.UTF_8))
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (SignatureException | MalformedJwtException | MissingClaimException ex) {
+            throw new CustomException(ResponseCode.MODULATION_JWT);
+        } catch (ExpiredJwtException ex) {
+            throw new CustomException(ResponseCode.EXPIRATION_JWT);
+        }
     }
 }

--- a/src/main/java/com/sosim/server/security/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sosim/server/security/filter/AuthenticationFilter.java
@@ -1,6 +1,7 @@
-package com.sosim.server.security;
+package com.sosim.server.security.filter;
 
 import com.sosim.server.jwt.util.JwtProvider;
+import com.sosim.server.security.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/sosim/server/security/filter/JwtFailureFilter.java
+++ b/src/main/java/com/sosim/server/security/filter/JwtFailureFilter.java
@@ -1,0 +1,34 @@
+package com.sosim.server.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.response.Response;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtFailureFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            responseJwtError(response, e);
+        }
+    }
+
+    public void responseJwtError(HttpServletResponse response, CustomException e) throws IOException {
+        response.setStatus(e.getResponseCode().getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Response<?> responseValue = Response.create(e.getResponseCode(), null);
+
+        new ObjectMapper().writeValue(response.getOutputStream(), responseValue);
+    }
+}


### PR DESCRIPTION
## 👀 개요

- Closes #26 
- JWT Token이 없어도 Security의 ContextFilter를 통과하던 문제 발견

<!--


- 간단한 설명

-->

<br />

## 🧑‍💻 구현 디테일 및 화면

- Filter 단에서 JWT 예외 캐치 사용
- permitAll() 로 다 열어준 뒤, authenticated() 막으려고 하니 안되던 점 수정

  - antMatchers 순서 수정

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->



<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


