### PR TITLE
Feat: AuthUserId 어노테이션에 required 속성 추가

### DIFF
--- a/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
@@ -21,11 +21,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        try {
+        AuthUserId annotation = parameter.getParameterAnnotation(AuthUserId.class);
+        assert annotation != null;
+        if (annotation.required()) {
             AuthUser authUser = (AuthUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
             return authUser.getId();
-        } catch (ClassCastException e) {
-            return 0L;
         }
+        return 0L;
     }
 }

--- a/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
@@ -27,7 +27,6 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         Authentication authentication = SecurityContextHolder
                 .getContext()
                 .getAuthentication();
-        System.out.println("authentication = " + authentication);
         if (annotation.required() || authentication != null) {
             AuthUser authUser = (AuthUser) authentication.getPrincipal();
             return authUser.getId();

--- a/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserArgumentResolver.java
@@ -2,6 +2,7 @@ package com.sosim.server.common.resolver;
 
 import com.sosim.server.security.AuthUser;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -23,8 +24,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         AuthUserId annotation = parameter.getParameterAnnotation(AuthUserId.class);
         assert annotation != null;
-        if (annotation.required()) {
-            AuthUser authUser = (AuthUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Authentication authentication = SecurityContextHolder
+                .getContext()
+                .getAuthentication();
+        System.out.println("authentication = " + authentication);
+        if (annotation.required() || authentication != null) {
+            AuthUser authUser = (AuthUser) authentication.getPrincipal();
             return authUser.getId();
         }
         return 0L;

--- a/src/main/java/com/sosim/server/common/resolver/AuthUserId.java
+++ b/src/main/java/com/sosim/server/common/resolver/AuthUserId.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthUserId {
+    boolean required() default true;
 }

--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -21,7 +21,9 @@ public class SecurityConfig {
 
     @Bean
     public WebSecurityCustomizer configure() {
-        return (web) -> web.ignoring().antMatchers("/auth/**");
+        return (web) -> web.ignoring()
+                .antMatchers("/auth/**")
+                .antMatchers("/api/group/{groupId}");
     }
 
     @Bean

--- a/src/main/java/com/sosim/server/group/GroupController.java
+++ b/src/main/java/com/sosim/server/group/GroupController.java
@@ -30,7 +30,7 @@ public class GroupController {
     }
 
     @GetMapping("/group/{groupId}")
-    public ResponseEntity<?> getGroup(@AuthUserId long userId, @PathVariable long groupId) {
+    public ResponseEntity<?> getGroup(@AuthUserId(required = false) long userId, @PathVariable long groupId) {
         GetGroupResponse getGroupResponse = groupService.getGroup(userId, groupId);
 
         return new ResponseEntity<>(Response.create(GET_GROUP, getGroupResponse), GET_GROUP.getHttpStatus());

--- a/src/test/java/com/sosim/server/group/GroupControllerTest.java
+++ b/src/test/java/com/sosim/server/group/GroupControllerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static com.sosim.server.common.response.ResponseCode.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -241,6 +242,23 @@ class GroupControllerTest {
                 .andExpect(jsonPath("$.status.code").value(NOT_FOUND_GROUP.getCode()))
                 .andExpect(jsonPath("$.status.message").value(NOT_FOUND_GROUP.getMessage()))
                 .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @DisplayName("그룹 조회 / 인증 없이 조회하는 경우")
+    @Test
+    void get_group_no_userId() throws Exception {
+        //given
+        GetGroupResponse getGroupResponse = makeGetGroupResponse();
+
+        doReturn(getGroupResponse).when(groupService).getGroup(0L, groupId);
+
+        //when
+        String url = URI_PREFIX.concat(String.format("/%d", groupId));
+        ResultActions resultActions = mvc.perform(get(url));
+
+        //then
+        resultActions.andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.status.code").value(GET_GROUP.getCode()));
     }
 
     @WithMockCustomUser


### PR DESCRIPTION
- Group 조회 API에서 인증되지 않은 사용자인 경우 userId 값 바인딩 에러를 해결하기 위해 도입

## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- @AuthUserId에 required 속성을 추가해서 인증되지 않은 사용자의 요청인 경우 0L을 바인딩

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
