### PR TITLE
Fix : User 회원 탈퇴 검증 로직 수정

### DIFF
--- a/src/main/java/com/sosim/server/participant/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface ParticipantRepository extends JpaRepository<Participant, java.lang.Long> {
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
     @Query("select p from Participant p where p.user.id = :userId " +
             "and p.group.id = :groupId and p.status = 'ACTIVE'")
@@ -25,10 +25,11 @@ public interface ParticipantRepository extends JpaRepository<Participant, java.l
             "ORDER BY p.nickname ASC")
     List<Participant> findGroupNormalParticipants(@Param("groupId") long groupId, @Param("adminNickname") String adminNickname);
 
-    @Query("SELECT p FROM Participant p " +
+    @Query("SELECT DISTINCT p FROM Participant p " +
+            "JOIN FETCH p.group g " +
+            "JOIN FETCH g.participantList " +
             "WHERE p.status = 'ACTIVE' " +
-            "AND p.user.id = :userId " +
-            "AND p.isAdmin = true")
+            "AND p.user.id = :userId AND p.isAdmin = true")
     List<Participant> findByUserIdAndIsAdminIsTrue(@Param("userId") long userId);
 
     @Query("SELECT p FROM Participant p " +

--- a/src/main/java/com/sosim/server/user/UserService.java
+++ b/src/main/java/com/sosim/server/user/UserService.java
@@ -60,9 +60,11 @@ public class UserService {
 
     private void checkCanWithdraw(long userId) {
         List<Participant> myParticipants = participantRepository.findByUserIdAndIsAdminIsTrue(userId);
-        if (myParticipants.stream().anyMatch(Participant::isAdmin)) {
-            throw new CustomException(CANNOT_WITHDRAWAL_BY_GROUP_ADMIN);
-        }
+        myParticipants.forEach(p -> {
+            if (p.getGroup().getNumberOfParticipants() > 1) {
+                throw new CustomException(CANNOT_WITHDRAWAL_BY_GROUP_ADMIN);
+            }
+        });
     }
 
     private User getUser(OAuthUserRequest oAuthUserRequest) {


### PR DESCRIPTION
## 👀 개요

- Closes #54 

<!--


- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

- 본인이 총무지만 다른 참가자가 없을 경우, 회원 탈퇴가 가능해야함
- 본인 Participant를 통해 Group으로 Fetch 후, Group의 Participants Fetch 방향으로 조정

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->



<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


