### PR TITLE
Fix : Security의 antMatcher 메서드 추가

### DIFF
--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.sosim.server.security.filter.AuthenticationFilter;
 import com.sosim.server.security.filter.JwtFailureFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -42,7 +43,7 @@ public class SecurityConfig {
         // 요청에 대한 권한 체크 파트
         http
                 .authorizeRequests()
-                .antMatchers("/api/group/{groupId}").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/group/{groupId}").permitAll()
                 .antMatchers("/api/**").authenticated()
                 .antMatchers("/**").permitAll();
 


### PR DESCRIPTION
## 👀 개요
- "/api/group/{groupId}" URI 의 permitAll 설정의 문제점 발견
  - 토큰이 없어도 요청이 가능한 상황

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->
- GET 요청만 permitAll 설정 추가


<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


