### PR TITLE
Refactor: participant create 로직 Group으로 변경

### DIFF
--- a/src/main/java/com/sosim/server/group/Group.java
+++ b/src/main/java/com/sosim/server/group/Group.java
@@ -5,6 +5,7 @@ import com.sosim.server.common.auditing.BaseTimeEntity;
 import com.sosim.server.common.response.ResponseCode;
 import com.sosim.server.group.dto.request.ModifyGroupRequest;
 import com.sosim.server.participant.Participant;
+import com.sosim.server.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,20 @@ public class Group extends BaseTimeEntity {
         this.coverColor = coverColor;
         this.groupType = groupType;
         status = ACTIVE;
+    }
+
+    public Participant createParticipant(User user, String nickname, boolean isAdmin) {
+        checkAlreadyIntoGroup(user.getId());
+        checkUsedNickname(nickname);
+
+        Participant participant = Participant.builder()
+                .user(user)
+                .group(this)
+                .nickname(nickname)
+                .isAdmin(isAdmin)
+                .build();
+        participant.addGroup(this);
+        return participant;
     }
 
     public void update(long userId, ModifyGroupRequest updateGroupRequest) {
@@ -147,4 +162,15 @@ public class Group extends BaseTimeEntity {
         }
     }
 
+    private void checkUsedNickname(String nickname) {
+        if (existThatNickname(nickname)) {
+            throw new CustomException(ALREADY_USE_NICKNAME);
+        }
+    }
+
+    private void checkAlreadyIntoGroup(long userId) {
+        if (hasParticipant(userId)) {
+            throw new CustomException(ALREADY_INTO_GROUP);
+        }
+    }
 }

--- a/src/main/java/com/sosim/server/group/GroupService.java
+++ b/src/main/java/com/sosim/server/group/GroupService.java
@@ -98,7 +98,7 @@ public class GroupService {
 
     private long saveGroupAndAdmin(CreateGroupRequest createGroupRequest, User user, Group group) {
         String adminNickname = createGroupRequest.getNickname();
-        Participant admin = Participant.create(user, group, adminNickname, true);
+        Participant admin = group.createParticipant(user, adminNickname, true);
         Group saveGroup = groupRepository.save(group);
         participantRepository.save(admin);
         return saveGroup.getId();

--- a/src/main/java/com/sosim/server/participant/Participant.java
+++ b/src/main/java/com/sosim/server/participant/Participant.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-import static com.sosim.server.common.response.ResponseCode.*;
+import static com.sosim.server.common.response.ResponseCode.ALREADY_USE_NICKNAME;
+import static com.sosim.server.common.response.ResponseCode.CANNOT_WITHDRAWAL_BY_GROUP_ADMIN;
 
 @Entity
 @Getter
@@ -44,20 +45,6 @@ public class Participant extends BaseTimeEntity {
         this.nickname = nickname;
         this.isAdmin = isAdmin;
         status = Status.ACTIVE;
-    }
-
-    public static Participant create(User user, Group group, String nickname, boolean isAdmin) {
-        checkAlreadyIntoGroup(user.getId(), group);
-        checkUsedNickname(group, nickname);
-
-        Participant participant = Participant.builder()
-                .user(user)
-                .group(group)
-                .nickname(nickname)
-                .isAdmin(isAdmin)
-                .build();
-        participant.addGroup(group);
-        return participant;
     }
 
     public void modifyNickname(Group group, String newNickname) {
@@ -102,15 +89,4 @@ public class Participant extends BaseTimeEntity {
         this.isAdmin = true;
     }
 
-    private static void checkUsedNickname(Group group, String nickname) {
-        if (group.existThatNickname(nickname)) {
-            throw new CustomException(ALREADY_USE_NICKNAME);
-        }
-    }
-
-    private static void checkAlreadyIntoGroup(long userId, Group group) {
-        if (group.hasParticipant(userId)) {
-            throw new CustomException(ALREADY_INTO_GROUP);
-        }
-    }
 }

--- a/src/main/java/com/sosim/server/participant/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantService.java
@@ -33,7 +33,7 @@ public class ParticipantService {
         User user = findUser(userId);
         Group group = findGroupWithParticipants(groupId);
 
-        Participant participant = Participant.create(user, group, nickname, false);
+        Participant participant = group.createParticipant(user, nickname, false);
         participantRepository.save(participant);
     }
 

--- a/src/test/java/com/sosim/server/group/GroupControllerTest.java
+++ b/src/test/java/com/sosim/server/group/GroupControllerTest.java
@@ -523,7 +523,7 @@ class GroupControllerTest {
     private Participant addParticipantInGroup(Group group, long userId, boolean isAdmin) {
         User user = new User();
         ReflectionTestUtils.setField(user, "id", userId);
-        return Participant.create(user, group, "닉네임" + userId, isAdmin);
+        return group.createParticipant(user, "닉네임" + userId, isAdmin);
     }
 
     @WithMockCustomUser

--- a/src/test/java/com/sosim/server/group/GroupRepositoryTest.java
+++ b/src/test/java/com/sosim/server/group/GroupRepositoryTest.java
@@ -191,10 +191,10 @@ class GroupRepositoryTest {
         Group group2 = groupRepository.save(makeGroup());
 
         List<Participant> participants = new ArrayList<>();
-        participants.add(Participant.create(user1, group1, "닉네임" + nicknameNo++, true));
-        participants.add(Participant.create(user1, group2, "닉네임" + nicknameNo++, false));
-        participants.add(Participant.create(user2, group1, "닉네임" + nicknameNo++, false));
-        participants.add(Participant.create(user2, group2, "닉네임" + nicknameNo++, true));
+        participants.add(group1.createParticipant(user1, makeNickname(), true));
+        participants.add(group2.createParticipant(user1, makeNickname(), false));
+        participants.add(group1.createParticipant(user2, makeNickname(), false));
+        participants.add(group2.createParticipant(user2, makeNickname(), true));
 
         for (Participant participant : participants) {
             participantRepository.save(participant);
@@ -220,7 +220,7 @@ class GroupRepositoryTest {
         List<Participant> participants = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             User user = userRepository.save(makeUser());
-            participants.add(Participant.create(user, group, "닉네임" + nicknameNo++, false));
+            participants.add(group.createParticipant(user, makeNickname(), false));
         }
         participants.get(0).signOn();
         for (int i = 1; i <= deletedN; i++) {
@@ -235,6 +235,10 @@ class GroupRepositoryTest {
         return n - deletedN;
     }
 
+    private String makeNickname() {
+        return "닉네임" + nicknameNo++;
+    }
+
     private void saveMyGroupsData(int size) {
         User user = userRepository.save(makeUser());
         userId = user.getId();
@@ -246,7 +250,7 @@ class GroupRepositoryTest {
 
         List<Participant> participants = new ArrayList<>();
         for (int i = 0; i <= size; i++) {
-            participants.add(Participant.create(user, groups.get(i), "닉네임" + nicknameNo++, false));
+            participants.add(groups.get(i).createParticipant(user, makeNickname(), false));
         }
         participants.get(0).signOn();
         participants.get(size / 2).delete();

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -104,7 +104,7 @@ class GroupServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         String nickname = "닉네임";
-        Participant admin = Participant.create(user, group, nickname, true);
+        Participant admin = group.createParticipant(user, nickname, true);
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
 
@@ -305,7 +305,7 @@ class GroupServiceTest {
     private Participant addParticipantInGroup(Group group, long userId, boolean isAdmin) {
         User user = new User();
         ReflectionTestUtils.setField(user, "id", userId);
-        return Participant.create(user, group, "닉네임" + userId, isAdmin);
+        return group.createParticipant(user, "닉네임" + userId, isAdmin);
     }
 
     private static ModifyGroupRequest makeUpdateGroupRequest(String title, String groupType, String colorType, String nickname) {

--- a/src/test/java/com/sosim/server/participant/ParticipantRepositoryTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantRepositoryTest.java
@@ -119,7 +119,7 @@ class ParticipantRepositoryTest {
 
     private Participant makeParticipant(Group group, String nickname, boolean isAdmin) {
         User user = makeUser();
-        Participant participant = Participant.create(user, group, nickname, isAdmin);
+        Participant participant = group.createParticipant(user, nickname, isAdmin);
         return participant;
     }
 

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -495,7 +495,7 @@ class ParticipantServiceTest {
     private Participant addParticipantInGroup(Group group, long userId, boolean isAdmin) {
         User user = new User();
         ReflectionTestUtils.setField(user, "id", userId);
-        return Participant.create(user, group, "닉네임" + userId, isAdmin);
+        return group.createParticipant(user, "닉네임" + userId, isAdmin);
     }
 
 }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- Participant의 생성 규칙이 Group에 종속적이므로 Group 내부로 Participant의 Create 메소드를 옮겨서 Group을 Participant의 팩토리로서 활용하도록 리팩토링

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
