### PR TITLE
Refactor : 닉네임 변경 시, 본인 Event 닉네임 수정 로직 추가

### DIFF
--- a/src/main/java/com/sosim/server/event/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/EventRepository.java
@@ -15,6 +15,11 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "WHERE e.id IN (:eventIdList)")
     void updateSituationAll(@Param("eventIdList") List<Long> eventIdList, @Param("situation") Situation situation);
 
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Event e SET e.nickname = :newNickname " +
+            "WHERE e.nickname IN (:nickname)")
+    void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname);
+
     @Query("SELECT e FROM Event e JOIN FETCH e.group " +
             "WHERE e.id = :eventId AND e.status = 'ACTIVE'")
     Optional<Event> findByIdWithGroup(@Param("eventId") long eventId);

--- a/src/main/java/com/sosim/server/participant/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantService.java
@@ -1,6 +1,7 @@
 package com.sosim.server.participant;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.event.EventRepository;
 import com.sosim.server.group.Group;
 import com.sosim.server.group.GroupRepository;
 import com.sosim.server.participant.dto.NicknameSearchRequest;
@@ -27,6 +28,7 @@ public class ParticipantService {
     private final ParticipantRepository participantRepository;
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
+    private final EventRepository eventRepository;
 
     @Transactional
     public void createParticipant(long userId, long groupId, String nickname) {
@@ -62,7 +64,10 @@ public class ParticipantService {
         Group group = findGroupWithParticipants(groupId);
         Participant participant = findParticipant(userId, groupId);
 
+        String preNickname = participant.getNickname();
         participant.modifyNickname(group, newNickname);
+
+        eventRepository.updateNicknameAll(newNickname, preNickname);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -1,6 +1,7 @@
 package com.sosim.server.participant;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.event.EventRepository;
 import com.sosim.server.group.Group;
 import com.sosim.server.group.GroupRepository;
 import com.sosim.server.participant.dto.NicknameDto;
@@ -45,6 +46,9 @@ class ParticipantServiceTest {
 
     @Mock
     UserRepository userRepository;
+
+    @Mock
+    EventRepository eventRepository;
 
     @DisplayName("참가자 가입 / 정상")
     @Test
@@ -321,6 +325,7 @@ class ParticipantServiceTest {
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
         doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doNothing().when(eventRepository).updateNicknameAll(any(), any());
 
         //when
         participantService.modifyNickname(userId, groupId, newNickname);


### PR DESCRIPTION
## 👀 개요
- 현재 모임에서 본인 닉네임 변경 시, 상세 내역의 닉네임은 수정되지 않는 문제점 발생

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면
- 모임의 본인 닉네임 성공적으로 변경 시, 본인의 상세 내역 닉네임 일괄 변경 로직 추가

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->



<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


