### PR TITLE
Refactor : 상세 내역 변경 시, 탈퇴 팀원 알림 미전송 추가

### DIFF
--- a/src/main/java/com/sosim/server/event/EventService.java
+++ b/src/main/java/com/sosim/server/event/EventService.java
@@ -153,7 +153,7 @@ public class EventService {
 
     private List<String> getWithdrawNickname(List<Event> events, Group group) {
         List<String> nicknames = events.stream().map(Event::getNickname).collect(Collectors.toList());
-        return participantRepository.findAllByNicknameAndGroup(nicknames, group).stream()
+        return participantRepository.findAllByNicknameInAndGroup(nicknames, group).stream()
                 .map(Participant::getNickname)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/sosim/server/event/EventService.java
+++ b/src/main/java/com/sosim/server/event/EventService.java
@@ -9,8 +9,8 @@ import com.sosim.server.event.dto.response.*;
 import com.sosim.server.group.Group;
 import com.sosim.server.group.GroupRepository;
 import com.sosim.server.notification.util.NotificationUtil;
+import com.sosim.server.participant.Participant;
 import com.sosim.server.participant.ParticipantRepository;
-import com.sosim.server.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.sosim.server.common.response.ResponseCode.*;
 
@@ -33,10 +34,16 @@ public class EventService {
     @Transactional
     public EventIdResponse createEvent(Long userId, CreateEventRequest createEventRequest) {
         Group group = findGroupWithParticipants(createEventRequest.getGroupId());
-        User user = findUserByParticipant(createEventRequest.getGroupId(), createEventRequest.getNickname());
+        Participant participant = findParticipant(createEventRequest.getGroupId(), createEventRequest.getNickname());
+        boolean participantIsWithdraw = participant.isWithdrawGroup();
+
+        if (participantIsWithdraw) {
+            throw new CustomException(NOT_FOUND_PARTICIPANT);
+        }
+
         checkIsAdmin(group, userId);
 
-        Event event = saveEventEntity(createEventRequest.toEntity(group, user));
+        Event event = saveEventEntity(createEventRequest.toEntity(group, participant.getUser()));
         return EventIdResponse.toDto(event);
     }
 
@@ -52,14 +59,18 @@ public class EventService {
         Event event = findEventWithGroup(eventId);
         Group group = event.getGroup();
         checkIsAdmin(group, userId);
-        User user = findUserByParticipant(group.getId(), modifyEventRequest.getNickname());
 
-        boolean changedSituation = event.modifyAndCheckChangedSituation(user, modifyEventRequest);
-        if (changedSituation) {
-            notificationUtil.sendModifySituationNotifications(List.of(event), modifyEventRequest.getSituation());
+        Participant participant = findParticipant(group.getId(), modifyEventRequest.getNickname());
+        boolean participantIsWithdraw = participant.isWithdrawGroup();
+        boolean changedSituation = event.modifyAndCheckChangedSituation(participant.getUser(), modifyEventRequest);
+        GetEventResponse getEventResponse = GetEventResponse.toDto(event);
+
+        if (participantIsWithdraw || !changedSituation) {
+            return getEventResponse;
         }
 
-        return GetEventResponse.toDto(event);
+        notificationUtil.sendModifySituationNotifications(List.of(event), modifyEventRequest.getSituation());
+        return getEventResponse;
     }
 
     @Transactional
@@ -82,6 +93,8 @@ public class EventService {
         eventRepository.updateSituationAll(modifySituationRequest.getEventIdList(), modifySituationRequest.getSituation());
 
         if (group.isAdminUser(userId)) {
+            List<String> withdrawNicknames = getWithdrawNickname(events, group);
+            events = events.stream().filter(e -> !withdrawNicknames.contains(e.getNickname())).collect(Collectors.toList());
             notificationUtil.sendModifySituationNotifications(events, situation);
         } else {
             //TODO: events에 여러 사용자가 섞이는 경우 체크해야 하는지?
@@ -133,26 +146,15 @@ public class EventService {
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
 
-    private User findUserByParticipant(long groupId, String nickname) {
+    private Participant findParticipant(long groupId, String nickname) {
         return participantRepository.findByNicknameAndGroupId(nickname, groupId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT))
-                .getUser();
+                .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT));
     }
 
-    private List<Long> getReceiverUserIdList(ModifySituationRequest modifySituationRequest) {
-        if (modifySituationRequest.getSituation().equals(Situation.CHECK)) {
-            List<Long> receiverUserIdList = new ArrayList<>();
-            long adminUserId = eventRepository.getAdminUserId(modifySituationRequest.getEventIdList().get(0));
-            receiverUserIdList.add(adminUserId);
-            return receiverUserIdList;
-        }
-        return eventRepository.getReceiverUserIdList(modifySituationRequest.getEventIdList());
+    private List<String> getWithdrawNickname(List<Event> events, Group group) {
+        List<String> nicknames = events.stream().map(Event::getNickname).collect(Collectors.toList());
+        return participantRepository.findAllByNicknameAndGroup(nicknames, group).stream()
+                .map(Participant::getNickname)
+                .collect(Collectors.toList());
     }
-
-    private String getParticipantNickname(long userId, long groupId) {
-        return participantRepository.findByUserIdAndGroupId(userId, groupId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT))
-                .getNickname();
-    }
-
 }

--- a/src/main/java/com/sosim/server/event/Situation.java
+++ b/src/main/java/com/sosim/server/event/Situation.java
@@ -9,9 +9,9 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum Situation {
-    NONE("납부 전"),
-    FULL("납부완료"),
-    CHECK("승인대기"),
+    NONE("미납"),
+    FULL("완납"),
+    CHECK("확인중"),
     ;
 
     private String comment;

--- a/src/main/java/com/sosim/server/participant/Participant.java
+++ b/src/main/java/com/sosim/server/participant/Participant.java
@@ -97,4 +97,7 @@ public class Participant extends BaseTimeEntity {
         this.isAdmin = true;
     }
 
+    public boolean isWithdrawGroup() {
+        return this.status.equals(Status.DELETED);
+    }
 }

--- a/src/main/java/com/sosim/server/participant/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,4 +45,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     @Query("SELECT p.user.id FROM Participant p " +
             "WHERE p.status = 'ACTIVE' AND p.group.id = :groupId")
     List<Long> getReceiverUserIdList(@Param("groupId") long groupId);
+
+    List<Participant> findAllByNicknameAndGroup(List<String> nicknames, Group group);
 }

--- a/src/main/java/com/sosim/server/participant/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/ParticipantRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,5 +45,5 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "WHERE p.status = 'ACTIVE' AND p.group.id = :groupId")
     List<Long> getReceiverUserIdList(@Param("groupId") long groupId);
 
-    List<Participant> findAllByNicknameAndGroup(List<String> nicknames, Group group);
+    List<Participant> findAllByNicknameInAndGroup(List<String> nicknames, Group group);
 }

--- a/src/test/java/com/sosim/server/event/EventControllerTest.java
+++ b/src/test/java/com/sosim/server/event/EventControllerTest.java
@@ -60,7 +60,7 @@ public class EventControllerTest {
     @Test
     void create_event() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "미납");
         EventIdResponse response = EventIdResponse.builder().eventId(eventId).build();
 
         doReturn(response).when(eventService).createEvent(userId, request);
@@ -84,7 +84,7 @@ public class EventControllerTest {
     @Test
     void create_event_not_found_group() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NOT_FOUND_GROUP);
 
         doThrow(e).when(eventService).createEvent(userId, request);
@@ -106,7 +106,7 @@ public class EventControllerTest {
     @Test
     void create_event_not_found_participant() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NOT_FOUND_PARTICIPANT);
 
         doThrow(e).when(eventService).createEvent(userId, request);
@@ -128,7 +128,7 @@ public class EventControllerTest {
     @Test
     void create_event_none_admin() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NONE_ADMIN);
 
         doThrow(e).when(eventService).createEvent(userId, request);
@@ -150,8 +150,8 @@ public class EventControllerTest {
     @Test
     void create_event_valid_amount() throws Exception {
         // given
-        CreateEventRequest overAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), -1, "기타", "메모", "납부 전");
-        CreateEventRequest underAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1_000_001, "기타", "메모", "납부 전");
+        CreateEventRequest overAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), -1, "기타", "메모", "미납");
+        CreateEventRequest underAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1_000_001, "기타", "메모", "미납");
 
         // when
         ResultActions overResult = mvc.perform(post(URI_PREFIX)
@@ -177,7 +177,7 @@ public class EventControllerTest {
     @Test
     void create_event_valid_ground() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, null, "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, null, "메모", "미납");
 
         // when
         ResultActions resultActions = mvc.perform(post(URI_PREFIX)
@@ -255,7 +255,7 @@ public class EventControllerTest {
     @Test
     void modify_event() throws Exception {
         // given
-        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "납부 전");
+        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "미납");
         GetEventResponse response = makeGetEventResponse();
         doReturn(response).when(eventService).modifyEvent(userId, eventId, request);
 
@@ -279,7 +279,7 @@ public class EventControllerTest {
     @Test
     void modify_event_not_found_event() throws Exception {
         // given
-        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "납부 전");
+        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NOT_FOUND_EVENT);
         doThrow(e).when(eventService).modifyEvent(userId, eventId, request);
 
@@ -301,7 +301,7 @@ public class EventControllerTest {
     @Test
     void modify_event_none_admin() throws Exception {
         // given
-        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "납부 전");
+        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NONE_ADMIN);
         doThrow(e).when(eventService).modifyEvent(userId, eventId, request);
 
@@ -323,7 +323,7 @@ public class EventControllerTest {
     @Test
     void modify_event_not_found_participant() throws Exception {
         // given
-        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "납부 전");
+        ModifyEventRequest request = makeModifyRequest("닉네임", 1000, "기타", "메모", "미납");
         CustomException e = new CustomException(NOT_FOUND_PARTICIPANT);
         doThrow(e).when(eventService).modifyEvent(userId, eventId, request);
 
@@ -345,8 +345,8 @@ public class EventControllerTest {
     @Test
     void modify_event_valid_amount() throws Exception {
         // given
-        CreateEventRequest overAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), -1, "기타", "메모", "납부 전");
-        CreateEventRequest underAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1_000_001, "기타", "메모", "납부 전");
+        CreateEventRequest overAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), -1, "기타", "메모", "미납");
+        CreateEventRequest underAmount = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1_000_001, "기타", "메모", "미납");
 
         // when
         String url = URI_PREFIX.concat(String.format("/%d", eventId));
@@ -373,7 +373,7 @@ public class EventControllerTest {
     @Test
     void modify_event_valid_ground() throws Exception {
         // given
-        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, null, "메모", "납부 전");
+        CreateEventRequest request = makeCreateRequest(groupId, "닉네임", LocalDate.now(), 1000, null, "메모", "미납");
 
         // when
         String url = URI_PREFIX.concat(String.format("/%d", eventId));
@@ -470,7 +470,7 @@ public class EventControllerTest {
     @Test
     void modify_event_situation() throws Exception {
         // given
-        String situation = "승인대기";
+        String situation = "확인중";
         ModifySituationRequest request = makeModifySituationRequest(situation);
         ModifySituationResponse response = makeModifySituationResponse(situation);
         doReturn(response).when(eventService).modifyEventSituation(userId, request);
@@ -494,7 +494,7 @@ public class EventControllerTest {
     @Test
     void modify_event_situation_none_admin() throws Exception {
         // given
-        String situation = "납부완료";
+        String situation = "완납";
         ModifySituationRequest request = makeModifySituationRequest(situation);
         CustomException e = new CustomException(NONE_ADMIN);
         doThrow(e).when(eventService).modifyEventSituation(userId, request);
@@ -516,7 +516,7 @@ public class EventControllerTest {
     @Test
     void modify_event_situation_fail_to_check() throws Exception {
         // given
-        String situation = "승인대기";
+        String situation = "확인중";
         ModifySituationRequest request = makeModifySituationRequest(situation);
         CustomException e = new CustomException(FAIL_TO_CHECK);
         doThrow(e).when(eventService).modifyEventSituation(userId, request);


### PR DESCRIPTION
## 👀 개요
- 상세 내역 변경 시, 탈퇴한 팀원에겐 알림이 미 전송하는 정책

<!--

- Closes #이슈
- 간단한 설명

-->


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 단건 수정 시, 해당 참가자의 탈퇴 여부를 분기 처리로 알림 발송
- N개의 납부 여부 수정 시, 탈퇴한 팀원들의 닉네임을 가지는 상세 내역들은 제거 후 알림 발송

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


