### PR TITLE
Modify: 참가자 닉네임 검색에 탈퇴 여부 추가

### DIFF
--- a/src/main/java/com/sosim/server/participant/dto/NicknameDto.java
+++ b/src/main/java/com/sosim/server/participant/dto/NicknameDto.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class NicknameDto {
     private String nickname;
+    private boolean withdraw;
 }

--- a/src/main/java/com/sosim/server/participant/dto/NicknameSearchResponse.java
+++ b/src/main/java/com/sosim/server/participant/dto/NicknameSearchResponse.java
@@ -18,7 +18,7 @@ public class NicknameSearchResponse {
 
     private static List<NicknameDto> mapNicknameDtoList(List<Participant> participantList) {
         return participantList.stream()
-                .map(p -> new NicknameDto(p.getNickname()))
+                .map(p -> new NicknameDto(p.getNickname(), p.isWithdrawGroup()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/sosim/server/participant/ParticipantControllerTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantControllerTest.java
@@ -432,7 +432,7 @@ class ParticipantControllerTest {
         String keyword = "닉네임";
         request.setKeyword(keyword);
 
-        List<NicknameDto> list = List.of(new NicknameDto("닉네임1"), new NicknameDto("닉네임2"));
+        List<NicknameDto> list = List.of(new NicknameDto("닉네임1", false), new NicknameDto("닉네임2", false));
         NicknameSearchResponse response = new NicknameSearchResponse(list);
 
         doReturn(response).when(participantService).searchParticipants(groupId, request);
@@ -448,7 +448,9 @@ class ParticipantControllerTest {
                 .andExpect(jsonPath("$.status.message").value(SEARCH_PARTICIPANTS.getMessage()))
                 .andExpect(jsonPath("$.content.nicknameList").isArray())
                 .andExpect(jsonPath("$.content.nicknameList[0].nickname").value("닉네임1"))
-                .andExpect(jsonPath("$.content.nicknameList[1].nickname").value("닉네임2"));
+                .andExpect(jsonPath("$.content.nicknameList[0].withdraw").value(false))
+                .andExpect(jsonPath("$.content.nicknameList[1].nickname").value("닉네임2"))
+                .andExpect(jsonPath("$.content.nicknameList[1].withdraw").value(false));
     }
 
     private static GetParticipantListResponse makeGetParticipantsResponse(String adminNickname) {


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 참가자 닉네임 검색 응답에 탈퇴 여부 추가(API 명세서 반영)
**- Merge 후 Frontend에 명세서 변경된 부분 말씀 전달해주시면 좋을 것 같습니다.**

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

-

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
