### PR TITLE
Hotfix : Notification Setting Error 오류 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -156,9 +156,6 @@ public class Group extends BaseTimeEntity {
 
     public void changeNotificationSettingInfo(long userId, NotificationSettingInfo settingInfo) {
         checkIsAdmin(userId);
-        if (notSettingInfo()) {
-            return;
-        }
         //TODO: 타입이 다른 경우 아예 갈아끼워야 하는데, 정상 작동 여부 테스트 필요
         if (!isSameSettingType(settingInfo)) {
             notificationSettingInfo = settingInfo;
@@ -172,6 +169,7 @@ public class Group extends BaseTimeEntity {
     }
 
     private boolean isSameSettingType(NotificationSettingInfo newSettingInfo) {
+        if (notSettingInfo()) return false;
         return notificationSettingInfo.getSettingType().equals(newSettingInfo.getSettingType());
     }
 

--- a/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
@@ -65,12 +65,10 @@ public class MonthNotificationSettingInfo extends NotificationSettingInfo {
     @Override
     public void changeSettingInfoDetail(NotificationSettingInfo newSettingInfo) {
         MonthNotificationSettingInfo monthSettingInfo = (MonthNotificationSettingInfo) newSettingInfo;
-        if (SIMPLE_DATE.equals(monthSettingInfo.getMonthSettingType())) {
-            sendDay = monthSettingInfo.getSendDay();
-        } else {
-            weekOrdinalsOfMonth = monthSettingInfo.getWeekOrdinalsOfMonth();
-            daysOfWeek = monthSettingInfo.getDaysOfWeek();
-        }
+        monthSettingType = monthSettingInfo.getMonthSettingType();
+        sendDay = monthSettingInfo.getSendDay();
+        weekOrdinalsOfMonth = monthSettingInfo.getWeekOrdinalsOfMonth();
+        daysOfWeek = monthSettingInfo.getDaysOfWeek();
         setNextSendTime();
     }
 

--- a/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
@@ -22,5 +22,5 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     @Query("SELECT g FROM Group g " +
             "WHERE g.id = :groupId AND g.status = 'ACTIVE'")
     @EntityGraph(attributePaths = {"participantList", "notificationSettingInfo"})
-    Optional<Group> findByIdWithNotificationSettingInfo(long groupId);
+    Optional<Group> findByIdWithNotificationSettingInfo(@Param("groupId") long groupId);
 }

--- a/src/main/java/com/sosim/server/group/dto/request/NotificationSettingRequest.java
+++ b/src/main/java/com/sosim/server/group/dto/request/NotificationSettingRequest.java
@@ -22,7 +22,7 @@ public class NotificationSettingRequest {
 
     private String settingType;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YY.MM.dd", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     private LocalDate startDate;
 
     private int repeatCycle;

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -22,10 +22,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             "WHERE n.userId = :userId")
     void updateViewByUserId(@Param("userId") long userId);
 
-    @Query(value = "SELECT * FROM notifications n " +
-            "WHERE n.user_id = :userId " +
+    @Query("SELECT n FROM Notification n " +
+            "WHERE n.userId = :userId " +
             "AND n.reserved = false " +
-            "AND n.send_dateTime >= :time", nativeQuery = true)
+            "AND n.sendDateTime >= :time")
     Slice<Notification> findMyNotifications(@Param("userId") long userId, @Param("time") LocalDateTime time, Pageable pageable);
 
     @Query(value = "SELECT * FROM notifications n " +

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,6 +33,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             "WHERE n.send_dateTime <= CURRENT_TIMESTAMP AND n.reserved = true ", nativeQuery = true)
     List<Notification> findReservedNotifications();
 
+    @Modifying
+    @Transactional
     @Query("DELETE FROM Notification n " +
             "WHERE n.groupInfo.groupId = :groupId AND n.reserved = true")
     void deleteReservedNotifications(@Param("groupId") long groupId);


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `Native Query` 사용 시, `Controller` 의 `PageDefault` 값을 통해 `n.id` 로 DESC 정렬
  ->  `Notifications` 의 테이블 컬럼명은 `notificiation_id` 로 존재하므로 500 에러

- LocalDate Json Pattern 수정
  -> 현재 프론트 요청 방식 : "yyyy.MM.dd" 

- `Group` 의 `NotificationSettingInfo` 의 기본 값 `null` 
  -> `changeNotificationSettingInfo` 메서드 검증 로직 오류 발생

- JPA Delete Query 에러

- `MonthNotification` 의 `monthSettingType` 값 변경 되지 않는 문제점
<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Native Query` 삭제
- Json Pattern YY -> yyyy 수정
- `isSameSettingType` 메서드의 `null` 체크 로직 추가
- JPA Delete Query - `@Modifying`, `@Transactional` 어노테이션 추가
- `changeSettingInfoDetail` 메서드 로직 수정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


