### PR TITLE
Feat : AccessToken 커스텀 핸들링

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -44,7 +44,7 @@ public enum ResponseCode {
     NOT_EXIST_TOKEN_COOKIE(1200, HttpStatus.BAD_REQUEST, "리프레시 토큰이 존재하지 않습니다."),
     MODULATION_JWT(1201, HttpStatus.UNAUTHORIZED, "변조된 JWT 토큰 입니다."),
     EXPIRATION_JWT(1202, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
-    NOT_EXIST_TOKEN(1203, HttpStatus.UNAUTHORIZED, "엑세스 토큰이 존재하지 않습니다."),
+    NOT_EXIST_TOKEN(1203, HttpStatus.FORBIDDEN, "엑세스 토큰이 존재하지 않습니다."),
 
     NOT_FOUND_USER(1100, HttpStatus.NOT_FOUND, "존재하지 않는 회원 정보입니다."),
     USER_ALREADY_EXIST(1101, HttpStatus.BAD_REQUEST, "이미 존재하는 회원 정보입니다."),

--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -44,6 +44,7 @@ public enum ResponseCode {
     NOT_EXIST_TOKEN_COOKIE(1200, HttpStatus.BAD_REQUEST, "리프레시 토큰이 존재하지 않습니다."),
     MODULATION_JWT(1201, HttpStatus.UNAUTHORIZED, "변조된 JWT 토큰 입니다."),
     EXPIRATION_JWT(1202, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
+    NOT_EXIST_TOKEN(1203, HttpStatus.UNAUTHORIZED, "엑세스 토큰이 존재하지 않습니다."),
 
     NOT_FOUND_USER(1100, HttpStatus.NOT_FOUND, "존재하지 않는 회원 정보입니다."),
     USER_ALREADY_EXIST(1101, HttpStatus.BAD_REQUEST, "이미 존재하는 회원 정보입니다."),

--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.sosim.server.config;
 import com.sosim.server.jwt.util.JwtProvider;
 import com.sosim.server.security.filter.AuthenticationFilter;
 import com.sosim.server.security.filter.JwtFailureFilter;
+import com.sosim.server.security.handler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -49,6 +50,9 @@ public class SecurityConfig {
         http
                 .addFilterBefore(new AuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtFailureFilter(), AuthenticationFilter.class);
+
+        http
+                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint());
 
         return http.build();
     }

--- a/src/main/java/com/sosim/server/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sosim/server/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.sosim.server.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sosim.server.common.response.Response;
+import com.sosim.server.common.response.ResponseCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Response<?> responseValue = Response.create(ResponseCode.NOT_EXIST_TOKEN, null);
+
+        new ObjectMapper().writeValue(response.getOutputStream(), responseValue);
+    }
+}

--- a/src/main/java/com/sosim/server/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sosim/server/security/handler/CustomAuthenticationEntryPoint.java
@@ -2,8 +2,6 @@ package com.sosim.server.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sosim.server.common.response.Response;
-import com.sosim.server.common.response.ResponseCode;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -13,13 +11,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.sosim.server.common.response.ResponseCode.*;
+
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setStatus(NOT_EXIST_TOKEN.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        Response<?> responseValue = Response.create(ResponseCode.NOT_EXIST_TOKEN, null);
+        Response<?> responseValue = Response.create(NOT_EXIST_TOKEN, null);
 
         new ObjectMapper().writeValue(response.getOutputStream(), responseValue);
     }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- AccessToken 필요한 요청에 AccessToken 없을 경우, 자동으로 403 Forbidden
![image](https://github.com/so-sim/server/assets/123621015/04758d8d-d19f-4333-844c-6a7fa8a2f997)

- 정확한 정보 전달을 위한 핸들링 필요

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `AuthenticationEntryPoint` 구현 및 `SecurityConfig` 설정 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


