### PR TITLE
Feat : Group Title 수정 시, Notification Group Title 같이 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -60,10 +60,9 @@ public class GroupService {
     @Transactional
     public GroupIdResponse updateGroup(long userId, long groupId, ModifyGroupRequest modifyGroupRequest) {
         Group group = findGroup(groupId);
-        String preTitle = group.getTitle();
         group.update(userId, modifyGroupRequest);
 
-//        checkModifyNotificationGroupTitle(preTitle, modifyGroupRequest.getTitle(), groupId);
+        notificationUtil.modifyGroupTitle(groupId, group.getTitle());
         changeAdminNickname(group, modifyGroupRequest.getNickname());
 
         return GroupIdResponse.toDto(group.getId());
@@ -93,12 +92,6 @@ public class GroupService {
 
         List<MyGroupDto> myGroupDtoList = toMyGroupDtoList(userId, myGroups);
         return MyGroupsResponse.toResponseDto(myGroups.hasNext(), myGroupDtoList);
-    }
-
-    private void checkModifyNotificationGroupTitle(String preTitle, String newTitle, long groupId) {
-        if (!preTitle.equals(newTitle)) {
-            notificationUtil.modifyGroupTitle(groupId, newTitle);
-        }
     }
 
     private void changeAdminNickname(Group group, String newNickname) {

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -60,8 +60,10 @@ public class GroupService {
     @Transactional
     public GroupIdResponse updateGroup(long userId, long groupId, ModifyGroupRequest modifyGroupRequest) {
         Group group = findGroup(groupId);
+        String preTitle = group.getTitle();
         group.update(userId, modifyGroupRequest);
 
+//        checkModifyNotificationGroupTitle(preTitle, modifyGroupRequest.getTitle(), groupId);
         changeAdminNickname(group, modifyGroupRequest.getNickname());
 
         return GroupIdResponse.toDto(group.getId());
@@ -91,6 +93,12 @@ public class GroupService {
 
         List<MyGroupDto> myGroupDtoList = toMyGroupDtoList(userId, myGroups);
         return MyGroupsResponse.toResponseDto(myGroups.hasNext(), myGroupDtoList);
+    }
+
+    private void checkModifyNotificationGroupTitle(String preTitle, String newTitle, long groupId) {
+        if (!preTitle.equals(newTitle)) {
+            notificationUtil.modifyGroupTitle(groupId, newTitle);
+        }
     }
 
     private void changeAdminNickname(Group group, String newNickname) {

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -38,4 +38,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("DELETE FROM Notification n " +
             "WHERE n.groupInfo.groupId = :groupId AND n.reserved = true")
     void deleteReservedNotifications(@Param("groupId") long groupId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n SET n.groupInfo.groupTitle = :title " +
+            "WHERE n.groupInfo.groupId = :groupId")
+    void updateAllGroupTitleByGroupId(@Param("groupId") long groupId, @Param("title") String title);
 }

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -135,6 +136,12 @@ public class NotificationUtil {
                 .collect(Collectors.toList());
         notificationRepository.saveAll(notifications);
         sendNotifications(notifications);
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void modifyGroupTitle(long groupId, String newTitle) {
+        notificationRepository.updateAllGroupTitleByGroupId(groupId, newTitle);
     }
 
     private Notification makeChangeAdminNotification(Group group, Participant participant) {

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -12,6 +12,7 @@ import com.sosim.server.group.dto.response.GetGroupResponse;
 import com.sosim.server.group.dto.response.GroupIdResponse;
 import com.sosim.server.group.dto.response.MyGroupsResponse;
 import com.sosim.server.group.service.GroupService;
+import com.sosim.server.notification.util.NotificationUtil;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.participant.domain.repository.ParticipantRepository;
 import com.sosim.server.user.domain.entity.User;
@@ -51,6 +52,8 @@ class GroupServiceTest {
     UserRepository userRepository;
     @Mock
     ParticipantRepository participantRepository;
+    @Mock
+    NotificationUtil notificationUtil;
 
     @DisplayName("그룹 생성 / 성공")
     @Test
@@ -189,6 +192,7 @@ class GroupServiceTest {
         addParticipantInGroup(group, userId, true);
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doNothing().when(notificationUtil).modifyGroupTitle(groupId, title);
 
         //when
         GroupIdResponse response = groupService.updateGroup(userId, groupId, request);

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -192,7 +192,6 @@ class GroupServiceTest {
         addParticipantInGroup(group, userId, true);
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
-        doNothing().when(notificationUtil).modifyGroupTitle(groupId, title);
 
         //when
         GroupIdResponse response = groupService.updateGroup(userId, groupId, request);


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- Group Title 수정 시, Notification 의 Group Title 수정 안 되는 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `NotificationUtil` 의 `modifyGroupTitle` 메서드 생성

- `@Transactional(propagation = Propagation.MANDATORY)`
  -> `modifyGroup` 메서드의 트랜잭션에 합류

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


