### PR TITLE
Feat : 닉네임 수정 시, Notification의 Nickname 수정

### DIFF
--- a/src/main/java/com/sosim/server/SosimApplication.java
+++ b/src/main/java/com/sosim/server/SosimApplication.java
@@ -2,8 +2,10 @@ package com.sosim.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class SosimApplication {

--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -8,6 +8,7 @@ import com.sosim.server.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -20,6 +21,7 @@ import static com.sosim.server.common.response.ResponseCode.NOT_FULL_OR_NON_SITU
 @Getter
 @NoArgsConstructor
 @Table(name = "EVENTS")
+@DynamicUpdate
 public class Event extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -21,7 +21,6 @@ import static com.sosim.server.common.response.ResponseCode.NOT_FULL_OR_NON_SITU
 @Getter
 @NoArgsConstructor
 @Table(name = "EVENTS")
-@DynamicUpdate
 public class Event extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -21,7 +21,7 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "WHERE e.id IN (:eventIdList)")
     void updateSituationAll(@Param("eventIdList") List<Long> eventIdList, @Param("situation") Situation situation);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE Event e SET e.nickname = :newNickname " +
             "WHERE e.nickname IN (:nickname)")
     void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname);

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -23,8 +23,9 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
     @Modifying
     @Query("UPDATE Event e SET e.nickname = :newNickname " +
-            "WHERE e.nickname IN (:nickname)")
-    void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname);
+            "WHERE e.nickname IN (:nickname) AND " +
+            "e.group.id = :groupId")
+    void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname, @Param("groupId") long groupId);
 
     @Query("SELECT e FROM Event e JOIN FETCH e.group " +
             "WHERE e.id = :eventId AND e.status = 'ACTIVE'")

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ import static com.sosim.server.common.response.ResponseCode.*;
 @Getter()
 @NoArgsConstructor
 @Table(name = "`GROUPS`")
+@DynamicUpdate
 public class Group extends BaseTimeEntity {
     public static final int DEFAULT_REPEAT_CYCLE = 1;
     public static final LocalTime DEFAULT_SEND_TIME = LocalTime.of(12, 0);

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -26,7 +26,6 @@ import static com.sosim.server.common.response.ResponseCode.*;
 @Getter()
 @NoArgsConstructor
 @Table(name = "`GROUPS`")
-@DynamicUpdate
 public class Group extends BaseTimeEntity {
     public static final int DEFAULT_REPEAT_CYCLE = 1;
     public static final LocalTime DEFAULT_SEND_TIME = LocalTime.of(12, 0);

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -100,7 +100,7 @@ public class GroupService {
         Participant admin = group.getAdminParticipant();
         String preNickname = admin.getNickname();
         admin.modifyNickname(group, newNickname);
-        eventRepository.updateNicknameAll(newNickname, preNickname);
+        eventRepository.updateNicknameAll(newNickname, preNickname, group.getId());
         notificationUtil.modifyNickname(group.getId(), preNickname, newNickname);
     }
 

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -100,6 +100,7 @@ public class GroupService {
         String preNickname = admin.getNickname();
         admin.modifyNickname(group, newNickname);
         eventRepository.updateNicknameAll(newNickname, preNickname);
+        notificationUtil.modifyNickname(group.getId(), preNickname, newNickname);
     }
 
     private List<MyGroupDto> toMyGroupDtoList(long userId, Slice<Group> myGroups) {

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.sosim.server.group.service;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
 import com.sosim.server.group.domain.util.MyGroupPaginationUtil;
@@ -35,6 +36,7 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final ParticipantRepository participantRepository;
+    private final EventRepository eventRepository;
     private final NotificationUtil notificationUtil;
 
     @Transactional
@@ -95,7 +97,9 @@ public class GroupService {
 
     private void changeAdminNickname(Group group, String newNickname) {
         Participant admin = group.getAdminParticipant();
+        String preNickname = admin.getNickname();
         admin.modifyNickname(group, newNickname);
+        eventRepository.updateNicknameAll(newNickname, preNickname);
     }
 
     private List<MyGroupDto> toMyGroupDtoList(long userId, Slice<Group> myGroups) {

--- a/src/main/java/com/sosim/server/notification/domain/entity/ContentType.java
+++ b/src/main/java/com/sosim/server/notification/domain/entity/ContentType.java
@@ -15,7 +15,7 @@ public enum ContentType {
     CHANGE_FULL_SITUATION("CHANGE_FULL_SITUATION", "납부여부 변경", "벌금을 모두 납부했습니다!", 1),
     CHANGE_NONE_SITUATION("CHANGE_NONE_SITUATION", "납부여부 변경", "내역이 \"납부 전\"으로 다시 변경되었습니다.", 1),
     CHANGE_CHECK_SITUATION("CHANGE_CHECK_SITUATION", "납부여부 변경", "승인대기 중인 내역이 있습니다.", 2),
-    CHANGE_ADMIN("CHANGE_ADMIN", "총무 변경", "총무가 변경되었습니다.", 0),
+    CHANGE_ADMIN("CHANGE_ADMIN", "총무 변경", "총무가 변경되었습니다.", 1),
     ;
 
     private final String type;

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -38,4 +38,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("DELETE FROM Notification n " +
             "WHERE n.groupInfo.groupId = :groupId AND n.reserved = true")
     void deleteReservedNotifications(@Param("groupId") long groupId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n SET n.content = :newNickname " +
+            "WHERE n.content.data1 = :nickname " +
+            "AND n.groupInfo.groupId = :groupId")
+    void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);
 }

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -40,7 +40,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void deleteReservedNotifications(@Param("groupId") long groupId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Notification n SET n.content = :newNickname " +
+    @Query("UPDATE Notification n SET n.content.data1 = :newNickname " +
             "WHERE n.content.data1 = :nickname " +
             "AND n.groupInfo.groupId = :groupId")
     void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -135,6 +136,12 @@ public class NotificationUtil {
                 .collect(Collectors.toList());
         notificationRepository.saveAll(notifications);
         sendNotifications(notifications);
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void modifyNickname(long groupId, String preNickname, String newNickname) {
+        notificationRepository.updateAllNicknameByGroupIdAndNickname(groupId, preNickname, newNickname);
     }
 
     private Notification makeChangeAdminNotification(Group group, Participant participant) {

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -139,13 +139,13 @@ public class NotificationUtil {
     }
 
     @Async
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional
     public void modifyNickname(long groupId, String preNickname, String newNickname) {
         notificationRepository.updateAllNicknameByGroupIdAndNickname(groupId, preNickname, newNickname);
     }
   
     @Async
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional
     public void modifyGroupTitle(long groupId, String newTitle) {
         notificationRepository.updateAllGroupTitleByGroupId(groupId, newTitle);
     }

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -138,7 +138,7 @@ public class NotificationUtil {
     }
 
     private Notification makeChangeAdminNotification(Group group, Participant participant) {
-        return Notification.toEntity(participant.getUser().getId(), group, Content.create(CHANGE_ADMIN));
+        return Notification.toEntity(participant.getUser().getId(), group, Content.create(CHANGE_ADMIN, group.getAdminParticipant().getNickname()));
     }
 
     private Notification makeModifySituationNotification(Event event, Situation preSituation, Situation newSituation) {

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -53,7 +52,7 @@ public class NotificationUtil {
     }
 
     @Transactional
-    @Scheduled(cron = "* */30 * * * *") //30분 마다
+    @Scheduled(cron = "0 */30 * * * *") //30분 마다
     public void sendRegularNotification() {
         List<Notification> reservedNotifications = notificationRepository.findReservedNotifications();
         reservedNotifications.forEach(this::sendReservedNotification);

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -8,6 +8,7 @@ import com.sosim.server.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
@@ -18,6 +19,7 @@ import static com.sosim.server.common.response.ResponseCode.CANNOT_WITHDRAWAL_BY
 @Getter
 @NoArgsConstructor
 @Table(name = "PARTICIPANTS")
+@DynamicUpdate
 public class Participant extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -19,7 +19,6 @@ import static com.sosim.server.common.response.ResponseCode.CANNOT_WITHDRAWAL_BY
 @Getter
 @NoArgsConstructor
 @Table(name = "PARTICIPANTS")
-@DynamicUpdate
 public class Participant extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -4,6 +4,7 @@ import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
+import com.sosim.server.notification.util.NotificationUtil;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.participant.domain.repository.ParticipantRepository;
 import com.sosim.server.participant.dto.NicknameSearchRequest;
@@ -31,6 +32,7 @@ public class ParticipantService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
+    private final NotificationUtil notificationUtil;
 
     @Transactional
     public void createParticipant(long userId, long groupId, String nickname) {
@@ -70,6 +72,7 @@ public class ParticipantService {
         participant.modifyNickname(group, newNickname);
 
         eventRepository.updateNicknameAll(newNickname, preNickname);
+        notificationUtil.modifyNickname(groupId, preNickname, newNickname);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -71,7 +71,7 @@ public class ParticipantService {
         String preNickname = participant.getNickname();
         participant.modifyNickname(group, newNickname);
 
-        eventRepository.updateNicknameAll(newNickname, preNickname);
+        eventRepository.updateNicknameAll(newNickname, preNickname, groupId);
         notificationUtil.modifyNickname(groupId, preNickname, newNickname);
     }
 

--- a/src/main/java/com/sosim/server/user/domain/entity/User.java
+++ b/src/main/java/com/sosim/server/user/domain/entity/User.java
@@ -7,6 +7,7 @@ import com.sosim.server.oauth.dto.request.OAuthUserRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
@@ -14,6 +15,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @Table(name = "USERS")
+@DynamicUpdate
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sosim/server/user/domain/entity/User.java
+++ b/src/main/java/com/sosim/server/user/domain/entity/User.java
@@ -15,7 +15,6 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @Table(name = "USERS")
-@DynamicUpdate
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/sosim/server/event/EventRepositoryTest.java
+++ b/src/test/java/com/sosim/server/event/EventRepositoryTest.java
@@ -27,6 +27,8 @@ public class EventRepositoryTest {
 
     private long eventId;
 
+    private Group group;
+
     private List<Long> eventIdList;
 
     @Autowired
@@ -42,6 +44,8 @@ public class EventRepositoryTest {
     void setUp() {
         eventRepository.deleteAll();
         eventIdList = new ArrayList<>();
+        group = Group.builder().build();
+        groupRepository.save(group);
         em.flush();
         em.clear();
     }
@@ -74,7 +78,8 @@ public class EventRepositoryTest {
 
         // when
         System.out.println("=============================");
-        eventRepository.updateNicknameAll(newNickname, preNickname);
+        eventRepository.updateNicknameAll(newNickname, preNickname, 1L);
+        em.clear();
         List<Event> events = eventRepository.findAllById(eventIdList);
 
         // then
@@ -155,8 +160,6 @@ public class EventRepositoryTest {
     }
 
     private Event makeEvent(Situation situation, String nickname) {
-        Group group = Group.builder().build();
-        groupRepository.save(group);
         return Event.builder()
                 .situation(situation)
                 .date(LocalDate.of(2023, 8, 1))

--- a/src/test/java/com/sosim/server/event/EventRepositoryTest.java
+++ b/src/test/java/com/sosim/server/event/EventRepositoryTest.java
@@ -168,8 +168,6 @@ public class EventRepositoryTest {
     private Event makeEvent(Situation situation, String nickname) {
         User user = User.builder().build();
         userRepository.save(user);
-        Group group = Group.builder().build();
-        groupRepository.save(group);
         return Event.builder()
                 .situation(situation)
                 .date(LocalDate.of(2023, 8, 1))

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -2,6 +2,7 @@ package com.sosim.server.group;
 
 import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.common.auditing.Status;
+import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
 import com.sosim.server.group.domain.util.MyGroupPaginationUtil;
@@ -51,6 +52,8 @@ class GroupServiceTest {
     UserRepository userRepository;
     @Mock
     ParticipantRepository participantRepository;
+    @Mock
+    EventRepository eventRepository;
 
     @DisplayName("그룹 생성 / 성공")
     @Test

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -55,7 +55,7 @@ class GroupServiceTest {
     ParticipantRepository participantRepository;
     @Mock
     EventRepository eventRepository;
-    @
+    @Mock
     NotificationUtil notificationUtil;
 
 

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -332,7 +332,7 @@ class ParticipantServiceTest {
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
         doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
-        doNothing().when(eventRepository).updateNicknameAll(any(), any(), any());
+        doNothing().when(eventRepository).updateNicknameAll(newNickname, participant.getNickname(), groupId);
 
         //when
         participantService.modifyNickname(userId, groupId, newNickname);

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -4,6 +4,7 @@ import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
+import com.sosim.server.notification.util.NotificationUtil;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.participant.domain.repository.ParticipantRepository;
 import com.sosim.server.participant.dto.NicknameDto;
@@ -52,6 +53,9 @@ class ParticipantServiceTest {
 
     @Mock
     EventRepository eventRepository;
+
+    @Mock
+    NotificationUtil notificationUtil;
 
     @DisplayName("참가자 가입 / 정상")
     @Test

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -332,7 +332,7 @@ class ParticipantServiceTest {
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
         doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
-        doNothing().when(eventRepository).updateNicknameAll(any(), any());
+        doNothing().when(eventRepository).updateNicknameAll(any(), any(), any());
 
         //when
         participantService.modifyNickname(userId, groupId, newNickname);


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 닉네임 수정 시, `Notification data1` 닉네임 수정 안되는 문제점
- 총무 변경 시, `Notification data1` 총무 닉네임이 없던 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


