### PR TITLE
Fix : 총무가 미납 or 완납 변경 시, 알림 전송 안 되는 오류 수정

### DIFF
--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -134,6 +134,9 @@ public class EventService {
     }
 
     private void validSituation(long userId, Group group, Situation preSituation, Situation newSituation) {
+        if (preSituation.equals(newSituation)) {
+            throw new CustomException(BINDING_ERROR, "situation", "동일 납부 여부 상태로 변경 불가능 합니다.");
+        }
         if (preSituation.canModifyToCheck(newSituation)) {
             throw new CustomException(NOT_FULL_TO_CHECK);
         }

--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -68,7 +68,7 @@ public class EventService {
 
         boolean participantIsWithdraw = participant.isWithdrawGroup();
         Situation newSituation = modifyEventRequest.getSituation();
-        if (!participantIsWithdraw && preSituation != newSituation) {
+        if (!group.isAdminUser(userId) && !participantIsWithdraw && preSituation != newSituation) {
             notificationUtil.sendModifySituationNotifications(List.of(event), preSituation, newSituation);
         }
         return GetEventResponse.toDto(event);

--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -1,6 +1,7 @@
 package com.sosim.server.event.service;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.domain.entity.Event;
 import com.sosim.server.event.domain.entity.Situation;
 import com.sosim.server.event.domain.repository.EventRepository;
@@ -177,7 +178,7 @@ public class EventService {
 
     private List<String> getWithdrawNickname(List<Event> events, Group group) {
         List<String> nicknames = events.stream().map(Event::getNickname).collect(Collectors.toList());
-        return participantRepository.findAllByNicknameInAndGroup(nicknames, group).stream()
+        return participantRepository.findAllByNicknameInAndGroupAndStatus(nicknames, group, Status.DELETED).stream()
                 .map(Participant::getNickname)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.sosim.server.participant.domain.repository;
 
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.participant.domain.entity.Participant;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -46,5 +47,5 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "WHERE p.status = 'ACTIVE' AND p.group.id = :groupId")
     List<Long> getReceiverUserIdList(@Param("groupId") long groupId);
 
-    List<Participant> findAllByNicknameInAndGroup(List<String> nicknames, Group group);
+    List<Participant> findAllByNicknameInAndGroupAndStatus(List<String> nicknames, Group group, Status status);
 }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 총무가 내 내역을 `완납` or `미납`으로 변경 시, 알림 발송 안 되는 문제점
- 총무가 본인의 내역을 변경 시, 알림 전송 되는 오류 

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `findAllByNicknameInAndGroup` 쿼리문 조건 수정
- `Event` 단건 수정 API의 알림 전송 조건 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
