### PR TITLE
Feat : 모임 탈퇴 or 회원 탈퇴 시, 본인 닉네임 알림 데이터 조작 방지

### DIFF
--- a/src/main/java/com/sosim/server/common/auditing/Status.java
+++ b/src/main/java/com/sosim/server/common/auditing/Status.java
@@ -4,5 +4,5 @@ import lombok.Getter;
 
 @Getter
 public enum Status {
-    ACTIVE, DORMANT, DELETED
+    ACTIVE, DORMANT, DELETED, LOCK
 }

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.sosim.server.notification.domain.repository;
 
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.notification.domain.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -42,11 +43,18 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification n SET n.content.data1 = :newNickname " +
             "WHERE n.content.data1 = :nickname " +
-            "AND n.groupInfo.groupId = :groupId")
+            "AND n.groupInfo.groupId = :groupId " +
+            "AND n.status <> 'LOCK'")
     void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification n SET n.groupInfo.groupTitle = :title " +
             "WHERE n.groupInfo.groupId = :groupId")
     void updateAllGroupTitleByGroupId(@Param("groupId") long groupId, @Param("title") String title);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n SET n.status = :status " +
+            "WHERE n.content.data1 = :nickname " +
+            "AND n.groupInfo.groupId = :groupId")
+    void updateAllStatusByNicknameAndGroupId(@Param("status") Status status, @Param("nickname") String nickname, @Param("groupId") long groupId);
 }

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -1,6 +1,7 @@
 package com.sosim.server.notification.util;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.common.response.Response;
 import com.sosim.server.event.domain.entity.Event;
 import com.sosim.server.event.domain.entity.Situation;
@@ -149,6 +150,12 @@ public class NotificationUtil {
         notificationRepository.updateAllGroupTitleByGroupId(groupId, newTitle);
     }
 
+    @Async
+    @Transactional
+    public void lockNotification(String nickname, long groupId) {
+        notificationRepository.updateAllStatusByNicknameAndGroupId(Status.LOCK, nickname, groupId);
+    }
+
     private Notification makeChangeAdminNotification(Group group, Participant participant) {
         return Notification.toEntity(participant.getUser().getId(), group, Content.create(CHANGE_ADMIN, group.getAdminParticipant().getNickname()));
     }
@@ -211,5 +218,4 @@ public class NotificationUtil {
         return groupRepository.findByIdWithParticipants(groupId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
-
 }

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -61,6 +61,7 @@ public class ParticipantService {
         Participant participant = findParticipant(userId, groupId);
 
         participant.withdrawGroup(group);
+        notificationUtil.lockNotification(participant.getNickname(), groupId);
     }
 
     @Transactional

--- a/src/main/java/com/sosim/server/user/service/UserService.java
+++ b/src/main/java/com/sosim/server/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.sosim.server.user.service;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.notification.util.NotificationUtil;
 import com.sosim.server.oauth.dto.request.OAuthUserRequest;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.participant.domain.repository.ParticipantRepository;
@@ -22,6 +23,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ParticipantRepository participantRepository;
+    private final NotificationUtil notificationUtil;
 
     @Transactional
     public User save(OAuthUserRequest oAuthUserRequest) {
@@ -51,6 +53,7 @@ public class UserService {
 
         user.delete(withdrawReason);
         myParticipants.forEach(Participant::withdrawGroup);
+        myParticipants.forEach(p -> notificationUtil.lockNotification(p.getNickname(), p.getGroup().getId()));
     }
 
     private void checkAlreadyExistUser(OAuthUserRequest oAuthUserRequest) {


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 회원 탈퇴 or 모임 탈퇴 시, 본인 닉네임으로 되어있는 알림 LOCK 처리 필요
    
    ex) 탈퇴한 회원의 닉네임으로 수정 후, 다시 새로운 닉네임 수정 시, 기존 알림의 `data1` 의 닉네임이 다 바뀜

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Status` 의 `LOCK` 추가
- 본인 닉네임의 알림 데이터들의 `Status`를 `LOCK` 으로 변경
- 닉네임 수정 시, 알림 데이터 `data1` 수정 조건의 `LOCK` 아닌 것들만 수정하도록 조건 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


