### PR TITLE
Refactor : notificationSettingInfo 변경 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -157,12 +157,7 @@ public class Group extends BaseTimeEntity {
 
     public void changeNotificationSettingInfo(long userId, NotificationSettingInfo settingInfo) {
         checkIsAdmin(userId);
-        //TODO: 타입이 다른 경우 아예 갈아끼워야 하는데, 정상 작동 여부 테스트 필요
-        if (!isSameSettingType(settingInfo)) {
-            notificationSettingInfo = settingInfo;
-            return;
-        }
-        notificationSettingInfo.changeSettingInfo(settingInfo);
+        notificationSettingInfo = settingInfo;
     }
 
     private boolean noSettingInfo() {

--- a/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
@@ -120,7 +120,7 @@ public class MonthNotificationSettingInfo extends NotificationSettingInfo {
     private LocalDateTime findSendDateTime(List<LocalDate> availableDates) {
         LocalDate sendDate = availableDates.get(0);
         for (LocalDate availableDate : availableDates) {
-            if (canNotSend(availableDate)) {
+            if (!canNotSend(availableDate)) {
                 sendDate = availableDate;
                 break;
             }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `toNotificationSettingInfo()` 메서드를 통해 알맞는 알림 날짜 생성 했지만 
 `changeSettingInfo()` 로 다시 한번 동일 로직 수행
![image](https://github.com/so-sim/server/assets/123621015/a7919062-b153-4e50-9cc0-a8e443cca9b8)
![image](https://github.com/so-sim/server/assets/123621015/1a2c88bd-c8b7-4d87-8836-6574719c6de5)

- 다음 알림 전송 날짜가 이전 날짜가 적용되던 문제 (8월 17일 기준)
![image](https://github.com/so-sim/server/assets/123621015/d67ca0f5-85aa-4555-9862-524dc1b19d6d)

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 데이터 자체를 변경하는 방식으로 수정
- 알림 설정 시, `canNotSend()`의 `return` 값을 반대로 적용

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

