### PR TITLE
Refactor : 납부 여부 변경의 Notification 데이터 수정

### DIFF
--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -102,6 +102,10 @@ public class Event extends BaseTimeEntity {
         this.situation = situation;
     }
 
+    public boolean isMine(long userId) {
+        return userId == user.getId();
+    }
+
     private void validSituation(Situation situation) {
         boolean isAdminUser = group.isAdminUser(user.getId());
         if (!isAdminUser && !situation.canModifyByParticipant()) {

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -27,8 +27,9 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "e.group.id = :groupId")
     void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname, @Param("groupId") long groupId);
 
-    @Query("SELECT e FROM Event e JOIN FETCH e.group " +
+    @Query("SELECT e FROM Event e " +
             "WHERE e.id = :eventId AND e.status = 'ACTIVE'")
+    @EntityGraph(attributePaths = {"user", "group"})
     Optional<Event> findByIdWithGroup(@Param("eventId") long eventId);
 
     @Query("SELECT e FROM Event e " +

--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -97,7 +97,9 @@ public class EventService {
 
         if (group.isAdminUser(userId)) {
             List<String> withdrawNicknames = getWithdrawNickname(events, group);
-            events = events.stream().filter(e -> !withdrawNicknames.contains(e.getNickname())).collect(Collectors.toList());
+            events = events.stream()
+                    .filter(e -> !withdrawNicknames.contains(e.getNickname()) && !e.getUser().getId().equals(userId))
+                    .collect(Collectors.toList());
             notificationUtil.sendModifySituationNotifications(events, preSituation, newSituation);
         } else {
             //TODO: events에 여러 사용자가 섞이는 경우 체크해야 하는지?

--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -98,7 +98,7 @@ public class EventService {
         if (group.isAdminUser(userId)) {
             List<String> withdrawNicknames = getWithdrawNickname(events, group);
             events = events.stream()
-                    .filter(e -> !withdrawNicknames.contains(e.getNickname()) && !e.getUser().getId().equals(userId))
+                    .filter(e -> isNotAdminAndNotWithdraw(userId, e, withdrawNicknames))
                     .collect(Collectors.toList());
             notificationUtil.sendModifySituationNotifications(events, preSituation, newSituation);
         } else {
@@ -134,6 +134,10 @@ public class EventService {
             events = eventRepository.findAllByEventIdList(userId, groupId, getEventIdListRequest.getEventIdList());
         }
         return GetEventIdListResponse.toDto(events);
+    }
+
+    private boolean isNotAdminAndNotWithdraw(long adminId, Event e, List<String> withdrawNicknames) {
+        return !withdrawNicknames.contains(e.getNickname()) && !e.isMine(adminId);
     }
 
     private void validSituation(long userId, Group group, Situation preSituation, Situation newSituation) {

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -157,12 +157,7 @@ public class Group extends BaseTimeEntity {
 
     public void changeNotificationSettingInfo(long userId, NotificationSettingInfo settingInfo) {
         checkIsAdmin(userId);
-        //TODO: 타입이 다른 경우 아예 갈아끼워야 하는데, 정상 작동 여부 테스트 필요
-        if (!isSameSettingType(settingInfo)) {
-            notificationSettingInfo = settingInfo;
-            return;
-        }
-        notificationSettingInfo.changeSettingInfo(settingInfo);
+        notificationSettingInfo = settingInfo;
     }
 
     private boolean noSettingInfo() {

--- a/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/MonthNotificationSettingInfo.java
@@ -120,7 +120,7 @@ public class MonthNotificationSettingInfo extends NotificationSettingInfo {
     private LocalDateTime findSendDateTime(List<LocalDate> availableDates) {
         LocalDate sendDate = availableDates.get(0);
         for (LocalDate availableDate : availableDates) {
-            if (canNotSend(availableDate)) {
+            if (!canNotSend(availableDate)) {
                 sendDate = availableDate;
                 break;
             }

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -15,7 +15,8 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     @Query("SELECT COUNT(*) FROM Notification n " +
             "WHERE n.userId = :userId AND n.createDate >= :time " +
-            "AND n.view = false")
+            "AND n.view = false " +
+            "AND n.reserved = false")
     Long countByUserIdBetweenMonth(@Param("userId") long userId, @Param("time") LocalDateTime time);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -129,19 +129,19 @@ public class NotificationUtil {
     public void sendModifySituationNotifications(List<Event> events, Situation preSituation, Situation newSituation) {
         events.sort(Comparator.comparing(e -> e.getUser().getId()));
         Group group = events.get(0).getGroup();
-        long id = events.get(0).getUser().getId();
+        long userId = events.get(0).getUser().getId();
         List<Notification> notifications = new ArrayList<>();
         List<Long> eventIdList = new ArrayList<>();
 
         for (Event event : events) {
-            if (id != event.getUser().getId()) {
-                notifications.add(makeModifySituationNotification(id, group, preSituation, newSituation, eventIdList));
-                id = event.getUser().getId();
+            if (!event.isMine(userId)) {
+                notifications.add(makeModifySituationNotification(userId, group, preSituation, newSituation, eventIdList));
+                userId = event.getUser().getId();
                 eventIdList = new ArrayList<>();
             }
             eventIdList.add(event.getId());
         }
-        notifications.add(makeModifySituationNotification(id, group, preSituation, newSituation, eventIdList));
+        notifications.add(makeModifySituationNotification(userId, group, preSituation, newSituation, eventIdList));
 
         notificationRepository.saveAll(notifications);
         sendNotifications(notifications);


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 납부 여부 `Situation` 변경 시, 알림 데이터를 개별로 생성
- `sendCheckSituationNotification` 형태로 압축 필요함 -> eventIdList 추가

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- eventIdList 추가 설정한 Notification 생성

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
