### PR TITLE
Refactor : 예약 알림 전송 로직 변경

### DIFF
--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -106,7 +106,7 @@ public class Event extends BaseTimeEntity {
     }
 
     public boolean included(Group group) {
-        return group.getId() == this.group.getId();
+        return group.getId().longValue() == this.group.getId().longValue();
     }
 
     private void validSituation(Situation situation) {

--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -8,7 +8,6 @@ import com.sosim.server.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -104,6 +103,10 @@ public class Event extends BaseTimeEntity {
 
     public boolean isMine(long userId) {
         return userId == user.getId();
+    }
+
+    public boolean included(Group group) {
+        return group.getId() == this.group.getId();
     }
 
     private void validSituation(Situation situation) {

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -2,6 +2,7 @@ package com.sosim.server.event.domain.repository;
 
 import com.sosim.server.event.domain.entity.Situation;
 import com.sosim.server.event.domain.entity.Event;
+import com.sosim.server.group.domain.entity.Group;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -54,4 +55,12 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "AND e.id IN (:eventIdList) ")
     @EntityGraph(attributePaths = {"user", "group"})
     List<Event> findAllByEventIdList(@Param("userId") long userId, @Param("groupId") long groupId, @Param("eventIdList") List<Long> eventIdList);
+
+    @Query("SELECT e FROM Event e " +
+            "WHERE e.status = 'ACTIVE' " +
+            "AND e.situation = 'NONE' " +
+            "AND e.group IN (:groups) " +
+            "ORDER BY e.user.id ASC AND e.group.id ASC")
+    @EntityGraph(attributePaths = {"user", "group"})
+    List<Event> findNoneEventsInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -60,7 +60,7 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "WHERE e.status = 'ACTIVE' " +
             "AND e.situation = 'NONE' " +
             "AND e.group IN (:groups) " +
-            "ORDER BY e.user.id ASC AND e.group.id ASC")
+            "ORDER BY e.user.id ASC, e.group.id ASC")
     @EntityGraph(attributePaths = {"user", "group"})
     List<Event> findNoneEventsInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -61,6 +61,6 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "AND e.situation = 'NONE' " +
             "AND e.group IN (:groups) " +
             "ORDER BY e.user.id ASC, e.group.id ASC")
-    @EntityGraph(attributePaths = {"user", "group"})
+    @EntityGraph(attributePaths = {"user", "group", "group.participantList"})
     List<Event> findNoneEventsInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -166,6 +166,10 @@ public class Group extends BaseTimeEntity {
         this.reservedSendNotificationDateTime = notificationSettingInfo.calculateNextSendDateTime();
     }
 
+    public boolean isReserveNotificationOn() {
+        return notificationSettingInfo.isEnableNotification();
+    }
+
     private boolean noSettingInfo() {
         return notificationSettingInfo == null;
     }

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -51,6 +50,9 @@ public class Group extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.ALL}, orphanRemoval = true)
     @JoinColumn(name = "NOTIFICATION_SETTING_INFO_ID")
     private NotificationSettingInfo notificationSettingInfo;
+
+    @Column
+    private LocalDateTime reservedSendNotificationDateTime;
 
     @Builder
     private Group(String title, String coverColor, String groupType) {
@@ -158,6 +160,10 @@ public class Group extends BaseTimeEntity {
     public void changeNotificationSettingInfo(long userId, NotificationSettingInfo settingInfo) {
         checkIsAdmin(userId);
         notificationSettingInfo = settingInfo;
+    }
+
+    public void setNextSendNotificationTime() {
+        this.reservedSendNotificationDateTime = notificationSettingInfo.calculateNextSendDateTime();
     }
 
     private boolean noSettingInfo() {

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -51,9 +51,6 @@ public class Group extends BaseTimeEntity {
     @JoinColumn(name = "NOTIFICATION_SETTING_INFO_ID")
     private NotificationSettingInfo notificationSettingInfo;
 
-    @Column
-    private LocalDateTime reservedSendNotificationDateTime;
-
     @Builder
     private Group(String title, String coverColor, String groupType) {
         this.title = title;
@@ -163,11 +160,7 @@ public class Group extends BaseTimeEntity {
     }
 
     public void setNextSendNotificationTime() {
-        this.reservedSendNotificationDateTime = notificationSettingInfo.calculateNextSendDateTime();
-    }
-
-    public boolean isReserveNotificationOn() {
-        return notificationSettingInfo.isEnableNotification();
+        this.notificationSettingInfo.nextSendDateTime = notificationSettingInfo.calculateNextSendDateTime();
     }
 
     private boolean noSettingInfo() {

--- a/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long>, GroupRepositoryDsl {
@@ -23,4 +25,9 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
             "WHERE g.id = :groupId AND g.status = 'ACTIVE'")
     @EntityGraph(attributePaths = {"participantList", "notificationSettingInfo"})
     Optional<Group> findByIdWithNotificationSettingInfo(@Param("groupId") long groupId);
+
+    @Query("SELECT g FROM Group g " +
+            "WHERE g.status = 'ACTIVE' " +
+            "AND g.reservedSendNotificationDateTime BETWEEN :before AND :after")
+    List<Group> findToSendReservationNotification(@Param("before") LocalDateTime before, @Param("after") LocalDateTime after);
 }

--- a/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
@@ -28,6 +28,8 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
 
     @Query("SELECT g FROM Group g " +
             "WHERE g.status = 'ACTIVE' " +
-            "AND g.reservedSendNotificationDateTime BETWEEN :before AND :after")
-    List<Group> findToSendReservationNotification(@Param("before") LocalDateTime before, @Param("after") LocalDateTime after);
+            "AND g.notificationSettingInfo.nextSendDateTime = :now " +
+            "AND g.notificationSettingInfo.enableNotification = true")
+    @EntityGraph(attributePaths = {"notificationSettingInfo"})
+    List<Group> findToNextSendDateTime(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/sosim/server/group/service/GroupNotificationSettingService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupNotificationSettingService.java
@@ -6,7 +6,6 @@ import com.sosim.server.group.domain.repository.GroupRepository;
 import com.sosim.server.group.domain.entity.NotificationSettingInfo;
 import com.sosim.server.group.dto.request.NotificationSettingRequest;
 import com.sosim.server.group.dto.response.NotificationSettingResponse;
-import com.sosim.server.notification.util.NotificationUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,6 @@ import static com.sosim.server.common.response.ResponseCode.NOT_FOUND_GROUP;
 public class GroupNotificationSettingService {
 
     private final GroupRepository groupRepository;
-    private final NotificationUtil notificationUtil;
 
     @Transactional(readOnly = true)
     public NotificationSettingResponse getNotificationSetting(long userId, long groupId) {
@@ -34,7 +32,6 @@ public class GroupNotificationSettingService {
 
         Group group = findGroupWithNotificationSettingInfo(groupId);
         group.changeNotificationSettingInfo(userId, settingInfo);
-        notificationUtil.changeReservedRegularNotifications(group);
     }
 
     private Group findGroupWithNotificationSettingInfo(long groupId) {

--- a/src/main/java/com/sosim/server/notification/domain/entity/Notification.java
+++ b/src/main/java/com/sosim/server/notification/domain/entity/Notification.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.sosim.server.common.response.ResponseCode.IS_NOT_NOTIFICATION_RECEIVER;
@@ -37,24 +36,16 @@ public class Notification extends BaseTimeEntity {
     @Column(name = "VIEW")
     private boolean view;
 
-    @Column(name = "SEND_DATETIME")
-    private LocalDateTime sendDateTime;
-
-    @Column(name = "RESERVED")
-    private boolean reserved;
-
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "event_ids", joinColumns = @JoinColumn(name = "notification_id"))
     @OrderColumn(name = "line_idx")
     private List<Long> eventIdList;
 
     @Builder
-    public Notification(long userId, long groupId, String groupTitle, Content content, LocalDateTime sendDateTime, boolean reserved, List<Long> eventIdList) {
+    public Notification(long userId, long groupId, String groupTitle, Content content, List<Long> eventIdList) {
         this.userId = userId;
         this.groupInfo = setGroupInfo(groupId, groupTitle);
         this.content = content;
-        this.sendDateTime = setSendDateTime(sendDateTime);
-        this.reserved = reserved;
         this.eventIdList = eventIdList;
     }
 
@@ -74,10 +65,6 @@ public class Notification extends BaseTimeEntity {
                 .content(content)
                 .eventIdList(eventIdList)
                 .build();
-    }
-
-    public void sendComplete() {
-        reserved = false;
     }
 
     public void read(long userId) {
@@ -113,10 +100,6 @@ public class Notification extends BaseTimeEntity {
         if (this.userId != userId) {
             throw new CustomException(IS_NOT_NOTIFICATION_RECEIVER);
         }
-    }
-
-    private LocalDateTime setSendDateTime(LocalDateTime sendDateTime) {
-        return sendDateTime == null ? LocalDateTime.now() : sendDateTime;
     }
 
     private GroupInfo setGroupInfo(long groupId, String groupTitle) {

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -16,8 +16,7 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     @Query("SELECT COUNT(*) FROM Notification n " +
             "WHERE n.userId = :userId AND n.createDate >= :time " +
-            "AND n.view = false " +
-            "AND n.reserved = false")
+            "AND n.view = false")
     Long countByUserIdBetweenMonth(@Param("userId") long userId, @Param("time") LocalDateTime time);
 
     @Modifying(clearAutomatically = true)
@@ -26,19 +25,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void updateViewByUserId(@Param("userId") long userId);
 
     @Query("SELECT n FROM Notification n " +
-            "WHERE n.userId = :userId " +
-            "AND n.reserved = false " +
-            "AND n.sendDateTime >= :time")
-    Slice<Notification> findMyNotifications(@Param("userId") long userId, @Param("time") LocalDateTime time, Pageable pageable);
+            "WHERE n.userId = :userId ")
+    Slice<Notification> findMyNotifications(@Param("userId") long userId, Pageable pageable);
 
     @Query(value = "SELECT * FROM notifications n " +
-            "WHERE n.send_dateTime <= CURRENT_TIMESTAMP AND n.reserved = true ", nativeQuery = true)
+            "WHERE n.send_dateTime <= CURRENT_TIMESTAMP", nativeQuery = true)
     List<Notification> findReservedNotifications();
 
     @Modifying
     @Transactional
     @Query("DELETE FROM Notification n " +
-            "WHERE n.groupInfo.groupId = :groupId AND n.reserved = true")
+            "WHERE n.groupInfo.groupId = :groupId")
     void deleteReservedNotifications(@Param("groupId") long groupId);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/sosim/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sosim/server/notification/dto/response/NotificationResponse.java
@@ -33,7 +33,7 @@ public class NotificationResponse {
 
     public static NotificationResponse toDto(Notification notification) {
         return NotificationResponse.builder()
-                .date(notification.getSendDateTime().toLocalDate())
+                .date(notification.getCreateDate().toLocalDate())
                 .type(notification.getType())
                 .groupId(notification.getGroupId())
                 .groupTitle(notification.getGroupTitle())

--- a/src/main/java/com/sosim/server/notification/service/NotificationService.java
+++ b/src/main/java/com/sosim/server/notification/service/NotificationService.java
@@ -46,7 +46,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public MyNotificationsResponse getMyNotifications(long userId, Pageable pageable) {
-        Slice<Notification> myNotifications = notificationRepository.findMyNotifications(userId, LocalDateTime.now().minusMonths(3), pageable);
+        Slice<Notification> myNotifications = notificationRepository.findMyNotifications(userId, pageable);
         List<NotificationResponse> notificationDtoList = toNotificationResponseList(myNotifications);
 
         return MyNotificationsResponse.toDto(notificationDtoList, myNotifications.hasNext());

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -148,12 +148,13 @@ public class NotificationUtil {
     }
 
     private List<Group> findNowReservedGroups() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Group> groups = groupRepository
-                .findToSendReservationNotification(now.minusMinutes(1), now.plusMinutes(1));
-        groups = groups.stream()
-                .filter(Group::isReserveNotificationOn)
-                .collect(Collectors.toList());
+        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
+        List<Group> groups = groupRepository.findToNextSendDateTime(now);
+
+        for (Group group : groups) {
+            group.setNextSendNotificationTime();
+        }
+
         return groups;
     }
 
@@ -179,7 +180,6 @@ public class NotificationUtil {
                         .toEntity(currentUserId, currentGroup, Content.create(PAYMENT_DATE), eventIdList));
 
                 currentUserId = event.getUser().getId();
-                currentGroup.setNextSendNotificationTime();
                 currentGroup = event.getGroup();
                 eventIdList = new ArrayList<>();
             }

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -55,6 +55,7 @@ public class NotificationUtil {
     @Transactional
     @Scheduled(cron = "0 */30 * * * *") //30분 마다
     public void sendRegularNotification() {
+        //TODO 로직 전면수정 필요
         List<Notification> reservedNotifications = notificationRepository.findReservedNotifications();
         reservedNotifications.forEach(this::sendReservedNotification);
 
@@ -178,14 +179,13 @@ public class NotificationUtil {
                 .groupId(group.getId())
                 .groupTitle(group.getTitle())
                 .content(Content.create(PAYMENT_DATE))
-                .reserved(true)
-                .sendDateTime(group.getNextNotifyDateTime())
                 .build();
     }
 
     private void sendReservedNotification(Notification notification) {
+
         sendNotification(notification);
-        notification.sendComplete();
+
     }
 
     private Response<?> makeNotificationResponse(Notification notification) {


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

### 변경 로직
1. 매 30분마다 해당 시간에 예약 알림 설정이 된 모임을 조회
2. 해당 모임에 해당하는 미납 내역 조회
3. 각 모임, 유저에 맞게 미납 내역 그룹화해서 알림 생성 후 전송

### 변경 사항
- Notification에 reserved, sendDateTime 컬럼 제거, Group에 reservedSendNotificationDateTime 추가 (DB 컬럼 변경 적용 필요)
- 이전 예약 알림 관련 로직 제거


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

-

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
