### PR TITLE
Hotfix : RefreshToken 브라우저 공유로 DB 삭제 로직 제거

### DIFF
--- a/src/main/java/com/sosim/server/jwt/controller/JwtController.java
+++ b/src/main/java/com/sosim/server/jwt/controller/JwtController.java
@@ -32,8 +32,7 @@ public class JwtController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
-        jwtService.delete(CookieUtil.getRefreshToken(request));
+    public ResponseEntity<?> logout(HttpServletResponse response) {
         CookieUtil.deleteRefreshToken(response);
         ResponseCode successLogout = ResponseCode.SUCCESS_LOGOUT;
 

--- a/src/main/java/com/sosim/server/jwt/service/JwtService.java
+++ b/src/main/java/com/sosim/server/jwt/service/JwtService.java
@@ -48,11 +48,6 @@ public class JwtService {
         return JwtResponse.create(jwtFactory.createAccessToken(refreshTokenEntity.getUserId()), refreshToken);
     }
 
-    public void delete(String refreshToken) {
-        if (refreshToken == null) return;
-        jwtRepository.deleteById(getRefreshTokenEntity(refreshToken).getUserId());
-    }
-
     private RefreshToken getRefreshTokenEntity(String refreshToken) {
         return jwtRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new CustomException(ResponseCode.MODULATION_JWT));


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `RefreshToken` 브라우저 공유로 DB 삭제 로직의 오류 발생
- 모바일, PC 크롬 브라우저 로그인 후, 모바일 로그아웃 시 DB의 `RefreshToken` 삭제되서
  PC 크롬 브라우저의 `RefreshToken` 무쓸모 되는 현상 발생

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `RefreshToken` 삭제 로직 제거

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


