### PR TITLE
Fix : Group NotificationSettingInfo 조회 API 총무가 아닐 경우 Response 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/controller/GroupNotificationSettingController.java
+++ b/src/main/java/com/sosim/server/group/controller/GroupNotificationSettingController.java
@@ -22,8 +22,8 @@ public class GroupNotificationSettingController {
     private final GroupNotificationSettingService groupSettingService;
 
     @GetMapping("/group/{groupId}/notification-info")
-    public ResponseEntity<?> getNotificationSetting(@AuthUserId long userId, @PathVariable long groupId) {
-        NotificationSettingResponse response = groupSettingService.getNotificationSetting(userId, groupId);
+    public ResponseEntity<?> getNotificationSetting(@PathVariable long groupId) {
+        NotificationSettingResponse response = groupSettingService.getNotificationSetting(groupId);
         return new ResponseEntity<>(Response.create(GET_GROUP_NOTIFICATION_SETTING, response), GET_GROUP_NOTIFICATION_SETTING.getHttpStatus());
     }
 

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -22,7 +22,7 @@ import static com.sosim.server.common.auditing.Status.ACTIVE;
 import static com.sosim.server.common.response.ResponseCode.*;
 
 @Entity
-@Getter()
+@Getter
 @NoArgsConstructor
 @Table(name = "`GROUPS`")
 public class Group extends BaseTimeEntity {
@@ -46,7 +46,6 @@ public class Group extends BaseTimeEntity {
     @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
     private List<Participant> participantList = new ArrayList<>();
 
-    @Getter(AccessLevel.NONE)
     @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.ALL}, orphanRemoval = true)
     @JoinColumn(name = "NOTIFICATION_SETTING_INFO_ID")
     private NotificationSettingInfo notificationSettingInfo;
@@ -120,11 +119,6 @@ public class Group extends BaseTimeEntity {
                 .filter(Participant::isAdmin)
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND_ADMIN));
-    }
-
-    public NotificationSettingInfo getNotificationSettingInfo(long userId) {
-        checkIsAdmin(userId);
-        return notificationSettingInfo;
     }
 
     public LocalDateTime getNextNotifyDateTime() {

--- a/src/main/java/com/sosim/server/group/service/GroupNotificationSettingService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupNotificationSettingService.java
@@ -19,9 +19,9 @@ public class GroupNotificationSettingService {
     private final GroupRepository groupRepository;
 
     @Transactional(readOnly = true)
-    public NotificationSettingResponse getNotificationSetting(long userId, long groupId) {
+    public NotificationSettingResponse getNotificationSetting(long groupId) {
         Group group = findGroupWithNotificationSettingInfo(groupId);
-        NotificationSettingInfo settingInfo = group.getNotificationSettingInfo(userId);
+        NotificationSettingInfo settingInfo = group.getNotificationSettingInfo();
 
         return NotificationSettingResponse.toResponse(settingInfo);
     }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- 총무가 아닐 경우 해당 `Group`의 `NotificationSettingInfo` 불러오질 못하는 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Getter`의 `AccessLevel` 제한 해제 및 기존 `getNotificationSettingInfo()` 삭제

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


