### PR TITLE
Feat : 유저별 알림 갯수 API 추가

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -47,6 +47,7 @@ public enum ResponseCode {
     VIEW_ALL_NOTIFICATIONS(successCode(), HttpStatus.OK, "모든 알림이 성공적으로 읽음 처리되었습니다."),
     VIEW_NOTIFICATION(successCode(), HttpStatus.OK, "해당 알림이 성공적으로 읽음 처리되었습니다."),
     GET_MY_NOTIFICATIONS(successCode(), HttpStatus.OK, "성공적으로 알림 목록이 조회되었습니다."),
+    GET_MY_NOTIFICATION_COUNT(successCode(), HttpStatus.OK, "성공적으로 알림 갯수가 조회되었습니다."),
 
     BINDING_ERROR(2000, HttpStatus.BAD_REQUEST, "입력값 중 검증에 실패한 값이 있습니다."),
     BAD_REQUEST(2001, HttpStatus.BAD_REQUEST, "올바르지 않은 요청입니다."),

--- a/src/main/java/com/sosim/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/sosim/server/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.sosim.server.notification.controller;
 
 import com.sosim.server.common.resolver.AuthUserId;
 import com.sosim.server.common.response.Response;
+import com.sosim.server.notification.dto.response.NotificationCountResponse;
 import com.sosim.server.notification.service.NotificationService;
 import com.sosim.server.notification.dto.response.MyNotificationsResponse;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,13 @@ public class NotificationController {
         MyNotificationsResponse myNotifications = notificationService.getMyNotifications(userId, pageable);
 
         return new ResponseEntity<>(Response.create(GET_MY_NOTIFICATIONS, myNotifications), GET_MY_NOTIFICATIONS.getHttpStatus());
+    }
+
+    @GetMapping("/notification/count")
+    public ResponseEntity<?> getMyNotificationCount(@AuthUserId long userId) {
+        NotificationCountResponse count = notificationService.getMyNotificationCount(userId);
+
+        return new ResponseEntity<>(Response.create(GET_MY_NOTIFICATION_COUNT, count), GET_MY_NOTIFICATION_COUNT.getHttpStatus());
     }
 
 }

--- a/src/main/java/com/sosim/server/notification/service/NotificationService.java
+++ b/src/main/java/com/sosim/server/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.notification.domain.entity.Notification;
 import com.sosim.server.notification.domain.repository.NotificationRepository;
 import com.sosim.server.notification.dto.response.MyNotificationsResponse;
+import com.sosim.server.notification.dto.response.NotificationCountResponse;
 import com.sosim.server.notification.dto.response.NotificationResponse;
 import com.sosim.server.notification.util.NotificationUtil;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public SseEmitter subscribe(long userId) {
-        return notificationUtil.subscribe(userId);
+        return notificationUtil.subscribe(userId, getNotificationCountByUserId(userId));
     }
 
     @Transactional
@@ -52,10 +53,20 @@ public class NotificationService {
         return MyNotificationsResponse.toDto(notificationDtoList, myNotifications.hasNext());
     }
 
+    @Transactional(readOnly = true)
+    public NotificationCountResponse getMyNotificationCount(long userId) {
+        return getNotificationCountByUserId(userId);
+    }
+
     private List<NotificationResponse> toNotificationResponseList(Slice<Notification> myNotifications) {
         return myNotifications.stream()
                 .map(NotificationResponse::toDto)
                 .collect(Collectors.toList());
     }
 
+    private NotificationCountResponse getNotificationCountByUserId(long userId) {
+        long count = notificationRepository.countByUserIdBetweenMonth(userId, LocalDateTime.now().minusMonths(3));
+
+        return NotificationCountResponse.toDto(count);
+    }
 }

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -45,11 +45,9 @@ public class NotificationUtil {
 
     private final SseEmitterRepository sseEmitterRepository;
 
-    public SseEmitter subscribe(long userId) {
+    public SseEmitter subscribe(long userId, NotificationCountResponse count) {
         SseEmitter sseEmitter = sseEmitterRepository.save(userId);
-        long userNotificationCount = notificationRepository.countByUserIdBetweenMonth(userId, LocalDateTime.now().minusMonths(3));
-        NotificationCountResponse notificationCount = NotificationCountResponse.toDto(userNotificationCount);
-        Response<?> subscribeResponse = Response.create(SUCCESS_SUBSCRIBE, notificationCount);
+        Response<?> subscribeResponse = Response.create(SUCCESS_SUBSCRIBE, count);
         sendToClient(sseEmitter, userId, "subscribe", subscribeResponse);
 
         return sseEmitter;


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 유저별 알림 갯수 조회 API 추가 필요 - 프론트 요청

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `NotificationRepository`의 기존 `countByUserIdBetweenMonth()` 메서드 활용 (3개월 제한 동일)
- `NotificationUtil`의 `subscribe()`의 `count` 로직 병합 

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


