### PR TITLE
Feat : 알림 목록 조회 시, 해당 알림의 ID 값 Response 추가

### DIFF
--- a/src/main/java/com/sosim/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sosim/server/notification/dto/response/NotificationResponse.java
@@ -12,6 +12,8 @@ import java.util.List;
 @Builder
 public class NotificationResponse {
 
+    private long notificationId;
+
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
@@ -33,6 +35,7 @@ public class NotificationResponse {
 
     public static NotificationResponse toDto(Notification notification) {
         return NotificationResponse.builder()
+                .notificationId(notification.getId())
                 .date(notification.getCreateDate().toLocalDate())
                 .type(notification.getType())
                 .groupId(notification.getGroupId())


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- 알림 개별 읽음 처리의 `notificationId` 값 필요
- `Notification List` 조회 시, 알림 마다 `Id` 값 없어서 해당 API 작동 불가

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `NotificationResponse`에 `notificationId` 필드 값 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


