### PR TITLE
Fix : Notification Nickname 변경 안 되는 문제점 수정

### DIFF
--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -42,7 +42,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("UPDATE Notification n SET n.content.data1 = :newNickname " +
             "WHERE n.content.data1 = :nickname " +
             "AND n.groupInfo.groupId = :groupId " +
-            "AND (n.status <> 'LOCK' n.status OR IS NULL)")
+            "AND (n.status <> 'LOCK' OR n.status IS NULL)")
     void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -42,7 +42,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("UPDATE Notification n SET n.content.data1 = :newNickname " +
             "WHERE n.content.data1 = :nickname " +
             "AND n.groupInfo.groupId = :groupId " +
-            "AND (n.status <> 'LOCK' OR IS NULL)")
+            "AND (n.status <> 'LOCK' n.status OR IS NULL)")
     void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/sosim/server/notification/domain/repository/NotificationRepository.java
@@ -42,7 +42,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("UPDATE Notification n SET n.content.data1 = :newNickname " +
             "WHERE n.content.data1 = :nickname " +
             "AND n.groupInfo.groupId = :groupId " +
-            "AND n.status <> 'LOCK'")
+            "AND (n.status <> 'LOCK' OR IS NULL)")
     void updateAllNicknameByGroupIdAndNickname(@Param("groupId") long groupId, @Param("nickname") String nickname, @Param("newNickname") String newNickname);
 
     @Modifying(clearAutomatically = true)


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- `Notifications` 테이블에 `Status`가 `NULL` 일 경우, `Nickname` 변경 로직 수행 안 되는 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `n.status <> 'LOCK' n.status OR IS NULL` 조건 수정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


