### PR TITLE
Feat : 닉네임 변경 로직 수정

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -67,11 +67,12 @@ public enum ResponseCode {
     NOT_FOUND_GROUP(1001, HttpStatus.NOT_FOUND, "해당 모임을 찾을 수 없습니다."),
     NONE_ADMIN(1002, HttpStatus.FORBIDDEN, "모임 관리자 권한이 필요합니다."),
     NOT_FOUND_PARTICIPANT(1003, HttpStatus.NOT_FOUND, "존재하지 않는 참가자 정보입니다."),
-    ALREADY_USE_NICKNAME(1004, HttpStatus.BAD_REQUEST, "모임에서 이미 사용중인 닉네임입니다."),
+    ALREADY_USE_NICKNAME(1004, HttpStatus.BAD_REQUEST, "모임 내 다른 팀원이 사용 중인 이름입니다."),
     NO_MORE_GROUP(1005, HttpStatus.BAD_REQUEST, "더 이상 조회할 모임이 없습니다."),
     ALREADY_INTO_GROUP(1006, HttpStatus.BAD_REQUEST, "이미 참여중인 모임입니다."),
     NONE_ZERO_PARTICIPANT(1007, HttpStatus.BAD_REQUEST, "모임에 다른 참가자가 존재합니다."),
     NOT_FOUND_ADMIN(1008, HttpStatus.NOT_FOUND, "모임의 총무를 찾을 수 없습니다."),
+    USED_NICKNAME(1009, HttpStatus.NOT_FOUND, "탈퇴 이력이 존재한 닉네임으로 변경 불가능 합니다."),
 
     NOT_FOUND_EVENT(1300, HttpStatus.BAD_REQUEST, "해당 상세 내역을 찾을 수 없습니다."),
     FAIL_TO_CHECK(1301, HttpStatus.BAD_REQUEST, "완납인 상세 내역은 확인중으로 변경 불가능합니다."),

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -25,7 +25,7 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
     @Modifying
     @Query("UPDATE Event e SET e.nickname = :newNickname " +
             "WHERE e.nickname IN (:nickname) AND " +
-            "e.group.id = :groupId")
+            "e.group.id = :groupId AND e.status <> 'LOCK'")
     void updateNicknameAll(@Param("newNickname") String newNickname, @Param("nickname") String nickname, @Param("groupId") long groupId);
 
     @Query("SELECT e FROM Event e " +
@@ -63,4 +63,10 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             "ORDER BY e.user.id ASC, e.group.id ASC")
     @EntityGraph(attributePaths = {"user", "group", "group.participantList"})
     List<Event> findNoneEventsInGroups(@Param("groups") List<Group> groups);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Event e SET " +
+            "e.status = 'LOCK' " +
+            "WHERE e.nickname = :nickname AND e.group = :group")
+    void lockEvent(@Param("nickname") String nickname, @Param("group") Group group);
 }

--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -137,6 +137,11 @@ public class Group extends BaseTimeEntity {
                 .anyMatch(p -> p.isActive() && p.getNickname().equals(nickname));
     }
 
+    public boolean existThatNicknameIgnoreStatus(String nickname) {
+        return getParticipantList().stream()
+                .anyMatch(p -> p.getNickname().equals(nickname));
+    }
+
     public boolean isAdminUser(long userId) {
         Participant admin = getAdminParticipant();
         return admin.isMine(userId);
@@ -196,7 +201,7 @@ public class Group extends BaseTimeEntity {
     }
 
     private void checkUsedNickname(String nickname) {
-        if (existThatNickname(nickname)) {
+        if (existThatNicknameIgnoreStatus(nickname)) {
             throw new CustomException(ALREADY_USE_NICKNAME);
         }
     }

--- a/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/sosim/server/group/domain/repository/GroupRepository.java
@@ -23,6 +23,11 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
 
     @Query("SELECT g FROM Group g " +
             "WHERE g.id = :groupId AND g.status = 'ACTIVE'")
+    @EntityGraph(attributePaths = {"participantList"})
+    Optional<Group> findByIdWithParticipantsIgnoreStatus(@Param("groupId") long groupId);
+
+    @Query("SELECT g FROM Group g " +
+            "WHERE g.id = :groupId AND g.status = 'ACTIVE'")
     @EntityGraph(attributePaths = {"participantList", "notificationSettingInfo"})
     Optional<Group> findByIdWithNotificationSettingInfo(@Param("groupId") long groupId);
 

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -61,7 +61,7 @@ public class GroupService {
 
     @Transactional
     public GroupIdResponse updateGroup(long userId, long groupId, ModifyGroupRequest modifyGroupRequest) {
-        Group group = findGroup(groupId);
+        Group group = findGroupWithParticipantsIgnoreStatus(groupId);
         group.update(userId, modifyGroupRequest);
 
         notificationUtil.modifyGroupTitle(groupId, group.getTitle());
@@ -124,6 +124,11 @@ public class GroupService {
 
     private Group findGroup(long groupId) {
         return groupRepository.findByIdWithParticipants(groupId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+    }
+
+    private Group findGroupWithParticipantsIgnoreStatus(long groupId) {
+        return groupRepository.findByIdWithParticipantsIgnoreStatus(groupId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
 

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -12,8 +12,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
-import static com.sosim.server.common.response.ResponseCode.ALREADY_USE_NICKNAME;
-import static com.sosim.server.common.response.ResponseCode.CANNOT_WITHDRAWAL_BY_GROUP_ADMIN;
+import static com.sosim.server.common.response.ResponseCode.*;
 
 @Entity
 @Getter
@@ -54,6 +53,9 @@ public class Participant extends BaseTimeEntity {
         }
         if (group.existThatNickname(newNickname)) {
             throw new CustomException(ALREADY_USE_NICKNAME);
+        }
+        if (group.existThatNicknameIgnoreStatus(newNickname)) {
+            throw new CustomException(USED_NICKNAME);
         }
         nickname = newNickname;
     }

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -195,7 +195,7 @@ class GroupServiceTest {
         ReflectionTestUtils.setField(group, "id", groupId);
         addParticipantInGroup(group, userId, true);
 
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         GroupIdResponse response = groupService.updateGroup(userId, groupId, request);
@@ -218,7 +218,7 @@ class GroupServiceTest {
         addParticipantInGroup(group, userId + 1, true);
         addParticipantInGroup(group, userId, false);
 
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -66,7 +66,7 @@ class ParticipantServiceTest {
         String nickname = "닉네임";
 
         doReturn(Optional.of(user)).when(userRepository).findById(userId);
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         participantService.createParticipant(userId, groupId, nickname);
@@ -99,7 +99,7 @@ class ParticipantServiceTest {
         String nickname = "닉네임";
 
         doReturn(Optional.of(user)).when(userRepository).findById(userId);
-        doReturn(Optional.empty()).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.empty()).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->
@@ -120,7 +120,7 @@ class ParticipantServiceTest {
         String nickname = "닉네임";
 
         doReturn(Optional.of(user)).when(userRepository).findById(userId);
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         CustomException exception = assertThrows(CustomException.class, () ->
@@ -141,7 +141,7 @@ class ParticipantServiceTest {
         addParticipantInGroup(group, userId + 2, false);
 
         doReturn(Optional.of(user)).when(userRepository).findById(userId);
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         CustomException exception = assertThrows(CustomException.class, () ->
@@ -330,7 +330,7 @@ class ParticipantServiceTest {
 
         String newNickname = "새닉네임";
 
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
         doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
         doNothing().when(eventRepository).updateNicknameAll(newNickname, participant.getNickname(), groupId);
 
@@ -347,7 +347,7 @@ class ParticipantServiceTest {
         //given
         String newNickname = "새닉네임";
 
-        doReturn(Optional.empty()).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.empty()).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->
@@ -364,7 +364,7 @@ class ParticipantServiceTest {
         String newNickname = "새닉네임";
         Group group = makeGroup();
 
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
         doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
 
         //when
@@ -386,7 +386,7 @@ class ParticipantServiceTest {
         group.getParticipantList().add(participant1);
         group.getParticipantList().add(participant2);
 
-        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
+        doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
         doReturn(Optional.of(participant1)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
 
         //when


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 기획 의도 : 탈퇴한 이력이 존재하는 닉네임으로 닉네임 변경 or 닉네임 생성 불가능

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Status` 조건 없이 모든 `Participant List` 조회 후,
  이미 존재하는 닉네임일 경우, `Status` 값으로 분기 처리 및 에러 메시지 커스텀

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


