### PR TITLE
Refactor : Event List의 Group, Situation 추출 로직 수정

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -79,6 +79,7 @@ public enum ResponseCode {
     NOT_FULL_OR_NON_SITUATION(1303, HttpStatus.BAD_REQUEST, "미납 또는 완납 상태로만 변경 가능합니다."),
     ONLY_CAN_HAVE_NONE_PAYMENT(1304, HttpStatus.BAD_REQUEST, "납부 요청은 미납 상태의 내역만 가능합니다."),
     NOT_FULL_TO_CHECK(1305, HttpStatus.BAD_REQUEST, "미납인 내역만 확인 중으로 변경 가능합니다."),
+    NOT_SAME_SITUATION(1306, HttpStatus.BAD_REQUEST, "모든 상세 내역이 동일한 납부 여부 상태가 아닙니다."),
 
     MUST_NEED_NOTIFICATION_MESSAGE_DATA(1306, HttpStatus.BAD_REQUEST, "알림 메시지 데이터가 반드시 필요합니다."),
     NOT_FOUND_NOTIFICATION(1307, HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),

--- a/src/main/java/com/sosim/server/event/service/EventService.java
+++ b/src/main/java/com/sosim/server/event/service/EventService.java
@@ -88,8 +88,8 @@ public class EventService {
     @Transactional
     public ModifySituationResponse modifyEventSituation(long userId, ModifySituationRequest modifySituationRequest) {
         List<Event> events = eventRepository.findAllById(modifySituationRequest.getEventIdList());
-        Group group = events.get(0).getGroup();
-        Situation preSituation = events.get(0).getSituation();
+        Group group = getGroup(events);
+        Situation preSituation = getPreSituation(events);
         Situation newSituation = modifySituationRequest.getSituation();
 
         validSituation(userId, group, preSituation, newSituation);
@@ -181,6 +181,34 @@ public class EventService {
         return participantRepository.findAllByNicknameInAndGroupAndStatus(nicknames, group, Status.DELETED).stream()
                 .map(Participant::getNickname)
                 .collect(Collectors.toList());
+    }
+
+    private Group getGroup(List<Event> events) {
+        Group group = events.get(0).getGroup();
+        if (isAllSame(events, group)) {
+            throw new CustomException(BAD_REQUEST);
+        }
+
+        return group;
+    }
+
+    private Situation getPreSituation(List<Event> events) {
+        Situation situation = events.get(0).getSituation();
+        if (isAllSame(events, situation)) {
+            throw new CustomException(NOT_SAME_SITUATION);
+        }
+
+        return situation;
+    }
+
+    private boolean isAllSame(List<Event> events, Situation situation) {
+        return events.stream()
+                .anyMatch(e -> !e.getSituation().equals(situation));
+    }
+
+    private boolean isAllSame(List<Event> events, Group group) {
+        return events.stream()
+                .anyMatch(e -> !e.getGroup().equals(group));
     }
 
 }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

```
Group group = events.get(0).getGroup();
Situation preSituation = events.get(0).getSituation();
```

- 위 로직일 경우, 0번째 index의 값으로만 로직 처리
- 즉, 다른 `Group` or 다른 `Situation`이어도 정상 수행되는 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Group`, `Situation` 따로 추출하는 메서드 작성

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->
