### PR TITLE
Hotfix : 모임 정렬 순서 수정 - Participant Id 순서

### DIFF
--- a/src/main/java/com/sosim/server/group/domain/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/sosim/server/group/domain/repository/GroupRepositoryImpl.java
@@ -37,7 +37,7 @@ public class GroupRepositoryImpl implements GroupRepositoryDsl {
                         participant.status.eq(ACTIVE),
                         admin.isAdmin.eq(true),
                         group.status.eq(ACTIVE))
-                .orderBy(group.id.desc())
+                .orderBy(participant.id.desc())
                 .offset(offset)
                 .limit(limit + 1)
                 .fetch();


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 메인 페이지 참가한 `Group` 정렬 순서
- 기획 : 참가한 순서대로
- 현재 : `Group`의 `Id` 순서

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

-  `.orderBy(participant.id.desc())`로 `Participant`의 `Id` 순서로 정렬

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


