### PR TITLE
Refactor : Event Status LOCK 처리된 데이터 알림 전송 안되는 로직 추가

### DIFF
--- a/src/main/java/com/sosim/server/event/domain/entity/Event.java
+++ b/src/main/java/com/sosim/server/event/domain/entity/Event.java
@@ -2,6 +2,7 @@ package com.sosim.server.event.domain.entity;
 
 import com.sosim.server.common.advice.exception.CustomException;
 import com.sosim.server.common.auditing.BaseTimeEntity;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.dto.request.ModifyEventRequest;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.user.domain.entity.User;
@@ -108,6 +109,8 @@ public class Event extends BaseTimeEntity {
     public boolean included(Group group) {
         return group.getId().longValue() == this.group.getId().longValue();
     }
+
+    public boolean isLock() {return this.status.equals(Status.LOCK);}
 
     private void validSituation(Situation situation) {
         boolean isAdminUser = group.isAdminUser(user.getId());

--- a/src/main/java/com/sosim/server/notification/service/PaymentNotificationService.java
+++ b/src/main/java/com/sosim/server/notification/service/PaymentNotificationService.java
@@ -58,6 +58,10 @@ public class PaymentNotificationService {
         Map<Long, NotificationDataDto> map = new HashMap<>();
         for (Event event : events) {
 
+            if (event.isLock()) {
+                continue;
+            }
+
             Long userId = event.getUser().getId();
             NotificationDataDto dataDto = map.compute(userId, (k, v) -> v == null ? new NotificationDataDto() : v);
             dataDto.addAmount(event.getAmount());

--- a/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
+++ b/src/main/java/com/sosim/server/notification/util/NotificationUtil.java
@@ -175,7 +175,7 @@ public class NotificationUtil {
 
         for (Event event : events) {
 
-            if (!currentGroup.existThatNickname(event.getNickname())) {
+            if (event.isLock()) {
                  continue;
             }
 


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `Event`의 미납`NONE`에 대한 납부 요청 알림이 탈퇴한 회원의 경우까지 발송되는 문제 발생

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Event` 의 `Status`가 `LOCK`인 경우, 알림 목록에서 제외시키는 로직 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


