### PR TITLE
Refactor : 토큰 예외 처리 세분화 및 회원 탈퇴 시, 리프레시 토큰 DB 삭제 추가

### DIFF
--- a/src/main/java/com/sosim/server/common/response/ResponseCode.java
+++ b/src/main/java/com/sosim/server/common/response/ResponseCode.java
@@ -55,10 +55,12 @@ public enum ResponseCode {
     NOT_SUPPORTED_OAUTH(1400, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 서비스입니다."),
     INCORRECT_OAUTH_CODE(1401, HttpStatus.BAD_REQUEST, "올바르지 않은 Authorization 코드입니다."),
 
-    NOT_EXIST_TOKEN_COOKIE(1200, HttpStatus.BAD_REQUEST, "리프레시 토큰이 존재하지 않습니다."),
-    MODULATION_JWT(1201, HttpStatus.UNAUTHORIZED, "변조된 JWT 토큰 입니다."),
-    EXPIRATION_JWT(1202, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
-    NOT_EXIST_TOKEN(1203, HttpStatus.FORBIDDEN, "엑세스 토큰이 존재하지 않습니다."),
+    NOT_EXIST_TOKEN_COOKIE(1200, HttpStatus.FORBIDDEN, "리프레시 토큰이 존재하지 않습니다."),
+    MODULATION_REFRESH(1201, HttpStatus.UNAUTHORIZED, "변조된 리프레시 토큰입니다."),
+    NOT_FOUNT_REFRESH(1202, HttpStatus.UNAUTHORIZED, "존재하지 않는 리프레시 토큰 데이터입니다."),
+    MODULATION_ACCESS(1203, HttpStatus.UNAUTHORIZED, "변조된 엑세스 토큰입니다."),
+    EXPIRATION_ACCESS(1204, HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다."),
+    NOT_EXIST_TOKEN(1205, HttpStatus.FORBIDDEN, "엑세스 토큰이 존재하지 않습니다."),
 
     NOT_FOUND_USER(1100, HttpStatus.NOT_FOUND, "존재하지 않는 회원 정보입니다."),
     USER_ALREADY_EXIST(1101, HttpStatus.BAD_REQUEST, "이미 존재하는 회원 정보입니다."),
@@ -72,7 +74,7 @@ public enum ResponseCode {
     ALREADY_INTO_GROUP(1006, HttpStatus.BAD_REQUEST, "이미 참여중인 모임입니다."),
     NONE_ZERO_PARTICIPANT(1007, HttpStatus.BAD_REQUEST, "모임에 다른 참가자가 존재합니다."),
     NOT_FOUND_ADMIN(1008, HttpStatus.NOT_FOUND, "모임의 총무를 찾을 수 없습니다."),
-    USED_NICKNAME(1009, HttpStatus.NOT_FOUND, "탈퇴 이력이 존재한 닉네임으로 변경 불가능 합니다."),
+    USED_NICKNAME(1009, HttpStatus.BAD_REQUEST, "탈퇴 이력이 존재한 닉네임으로 변경 불가능 합니다."),
 
     NOT_FOUND_EVENT(1300, HttpStatus.BAD_REQUEST, "해당 상세 내역을 찾을 수 없습니다."),
     FAIL_TO_CHECK(1301, HttpStatus.BAD_REQUEST, "완납인 상세 내역은 확인중으로 변경 불가능합니다."),

--- a/src/main/java/com/sosim/server/jwt/domain/util/JwtProvider.java
+++ b/src/main/java/com/sosim/server/jwt/domain/util/JwtProvider.java
@@ -20,28 +20,31 @@ public class JwtProvider {
 
     public boolean checkRenewRefreshToken(String refreshToken) {
         try {
-            getClaims(refreshKey, refreshToken);
+            getClaims(refreshKey, refreshToken, true);
         } catch (CustomException e) {
-            if (e.getResponseCode().equals(EXPIRATION_JWT)) return true;
+            if (e.getResponseCode().equals(EXPIRATION_ACCESS)) return true;
             else throw e;
         }
         return false;
     }
 
     public Long getUserId(String accessToken) {
-        return Long.valueOf(getClaims(accessKey, accessToken).getSubject());
+        return Long.valueOf(getClaims(accessKey, accessToken, false).getSubject());
     }
 
-    private Claims getClaims(String key, String token) {
+    private Claims getClaims(String key, String token, boolean isRefresh) {
         try {
             return Jwts.parser()
                     .setSigningKey(key.getBytes(StandardCharsets.UTF_8))
                     .parseClaimsJws(token)
                     .getBody();
         } catch (SignatureException | MalformedJwtException | MissingClaimException ex) {
-            throw new CustomException(MODULATION_JWT);
+            if (isRefresh) {
+                throw new CustomException(MODULATION_REFRESH);
+            }
+            throw new CustomException(MODULATION_ACCESS);
         } catch (ExpiredJwtException ex) {
-            throw new CustomException(EXPIRATION_JWT);
+            throw new CustomException(EXPIRATION_ACCESS);
         }
     }
 }

--- a/src/main/java/com/sosim/server/jwt/service/JwtService.java
+++ b/src/main/java/com/sosim/server/jwt/service/JwtService.java
@@ -54,6 +54,6 @@ public class JwtService {
 
     private RefreshToken getRefreshTokenEntity(String refreshToken) {
         return jwtRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new CustomException(ResponseCode.MODULATION_JWT));
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUNT_REFRESH));
     }
 }

--- a/src/main/java/com/sosim/server/jwt/service/JwtService.java
+++ b/src/main/java/com/sosim/server/jwt/service/JwtService.java
@@ -48,6 +48,10 @@ public class JwtService {
         return JwtResponse.create(jwtFactory.createAccessToken(refreshTokenEntity.getUserId()), refreshToken);
     }
 
+    public void deleteToken(long userId) {
+        jwtRepository.deleteById(userId);
+    }
+
     private RefreshToken getRefreshTokenEntity(String refreshToken) {
         return jwtRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new CustomException(ResponseCode.MODULATION_JWT));

--- a/src/main/java/com/sosim/server/user/controller/UserController.java
+++ b/src/main/java/com/sosim/server/user/controller/UserController.java
@@ -3,11 +3,13 @@ package com.sosim.server.user.controller;
 import com.sosim.server.common.resolver.AuthUserId;
 import com.sosim.server.common.response.Response;
 import com.sosim.server.common.util.CookieUtil;
+import com.sosim.server.jwt.service.JwtService;
 import com.sosim.server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static com.sosim.server.common.response.ResponseCode.CAN_WITHDRAW;
@@ -19,6 +21,7 @@ import static com.sosim.server.common.response.ResponseCode.SUCCESS_WITHDRAW;
 public class UserController {
 
     private final UserService userService;
+    private final JwtService jwtService;
 
     @GetMapping
     public ResponseEntity<?> checkWithdraw(@AuthUserId long userId) {
@@ -31,6 +34,7 @@ public class UserController {
     public ResponseEntity<?> withdrawUser(@AuthUserId long userId, @RequestParam("reason") String withdrawReason,
                                           HttpServletResponse response) {
         userService.withdrawUser(userId, withdrawReason);
+        jwtService.deleteToken(userId);
         CookieUtil.deleteRefreshToken(response);
 
         return new ResponseEntity<>(Response.create(SUCCESS_WITHDRAW, null), SUCCESS_WITHDRAW.getHttpStatus());

--- a/src/test/java/com/sosim/server/user/UserControllerTest.java
+++ b/src/test/java/com/sosim/server/user/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.sosim.server.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.jwt.service.JwtService;
 import com.sosim.server.security.WithMockCustomUser;
 import com.sosim.server.security.WithMockCustomUserSecurityContextFactory;
 import com.sosim.server.user.controller.UserController;
@@ -9,6 +10,7 @@ import com.sosim.server.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -34,6 +36,9 @@ class UserControllerTest {
     @MockBean
     @Autowired
     UserService userService;
+
+    @MockBean
+    JwtService jwtService;
 
     MockMvc mvc;
 


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 회원 탈퇴 시, DB 상의 `Refresh Token` 남아있는 문제점을 통해 새로운 `Access Token` 발급되는 문제점 발견

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 회원 탈퇴 진행 시, DB의 `Refresh Token` 삭제 처리 추가
- 위 로직을 통한 JWT 파싱 작업의 예외 처리 세분화 작업

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->


