### PR TITLE
Hotfix : Event LOCK 처리 시, 영속성 컨텍스트의 캐시를 클리어 여부 삭제

### DIFF
--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -64,7 +64,7 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
     @EntityGraph(attributePaths = {"user", "group", "group.participantList"})
     List<Event> findNoneEventsInGroups(@Param("groups") List<Group> groups);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("UPDATE Event e SET " +
             "e.status = 'LOCK' " +
             "WHERE e.nickname = :nickname AND e.group = :group")


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- 모임 탈퇴 시, 탈퇴 처리 안 되는 현상 발견
- `Participant`의 `Statsus` 값 안 바뀌는 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Event`의 `LOCK` 처리를 위한 메서드의 `@Modifying(clearAutomatically = true)` 의 캐시 클리어 삭제


<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

