### PR TITLE
Fix: 탈퇴한 팀원의 Event도 변경 가능하도록 변경

### DIFF
--- a/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
@@ -18,7 +18,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Participant> findByUserIdAndGroupId(@Param("userId") Long userId, @Param("groupId") Long groupId);
 
     @Query("select p from Participant p where p.nickname = :nickname " +
-           "and p.group.id = :groupId and p.status = 'ACTIVE'")
+           "and p.group.id = :groupId")
     @EntityGraph(attributePaths = {"user"})
     Optional<Participant> findByNicknameAndGroupId(@Param("nickname") String nickname, @Param("groupId") Long groupId);
 


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- 탈퇴한 팀원을 조회에서 걸러서 NOT_FOUND_PARTICIPANT Exception이 발생합니다. 따라서 탈퇴한 팀원 내역을 수정하지 못하는 문제가 발생했고 수정하였습니다.

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

-

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
