### PR TITLE
Fix: 모입 가입 or 닉네임 변경 시 탈퇴한 참가자 닉네임도 확인하도록 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -6,7 +6,6 @@ import com.sosim.server.common.response.ResponseCode;
 import com.sosim.server.group.dto.request.ModifyGroupRequest;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.user.domain.entity.User;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -60,7 +59,7 @@ public class Group extends BaseTimeEntity {
 
     public Participant createParticipant(User user, String nickname, boolean isAdmin) {
         checkAlreadyIntoGroup(user.getId());
-        checkUsedNickname(nickname);
+        //checkUsedNickname(nickname);
 
         Participant participant = Participant.builder()
                 .user(user)

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -53,9 +53,10 @@ public class Participant extends BaseTimeEntity {
 //        if (group.existThatNickname(newNickname)) {
 //            throw new CustomException(ALREADY_USE_NICKNAME);
 //        }
-        if (group.existThatNicknameIgnoreStatus(newNickname)) {
-            throw new CustomException(USED_NICKNAME);
-        }
+//
+//        if (group.existThatNicknameIgnoreStatus(newNickname)) {
+//            throw new CustomException(USED_NICKNAME);
+//        }
         nickname = newNickname;
     }
 

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -8,7 +8,6 @@ import com.sosim.server.user.domain.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
@@ -51,9 +50,9 @@ public class Participant extends BaseTimeEntity {
         if (nickname.equals(newNickname)) {
             return;
         }
-        if (group.existThatNickname(newNickname)) {
-            throw new CustomException(ALREADY_USE_NICKNAME);
-        }
+//        if (group.existThatNickname(newNickname)) {
+//            throw new CustomException(ALREADY_USE_NICKNAME);
+//        }
         if (group.existThatNicknameIgnoreStatus(newNickname)) {
             throw new CustomException(USED_NICKNAME);
         }

--- a/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
@@ -48,4 +48,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     List<Long> getReceiverUserIdList(@Param("groupId") long groupId);
 
     List<Participant> findAllByNicknameInAndGroupAndStatus(List<String> nicknames, Group group, Status status);
+
+    boolean existsByGroupAndNickname(Group group, String nickname);
 }

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -39,6 +39,8 @@ public class ParticipantService {
         User user = findUser(userId);
         Group group = findGroupWithParticipantsIgnoreStatus(groupId);
 
+        checkAlreadyUsedNickname(nickname, group);
+
         Participant participant = group.createParticipant(user, nickname, false);
         participantRepository.save(participant);
     }
@@ -71,6 +73,8 @@ public class ParticipantService {
         Participant participant = findParticipant(userId, groupId);
 
         String preNickname = participant.getNickname();
+
+        checkAlreadyUsedNickname(newNickname, group);
         participant.modifyNickname(group, newNickname);
 
         eventRepository.updateNicknameAll(newNickname, preNickname, groupId);
@@ -90,6 +94,12 @@ public class ParticipantService {
         List<Participant> participantList = participantRepository.findByGroupAndNicknameContainsIgnoreCase(group, searchRequest.getKeyword());
 
         return NicknameSearchResponse.toDto(participantList);
+    }
+
+    private void checkAlreadyUsedNickname(String nickname, Group group) {
+        if (participantRepository.existsByGroupAndNickname(group, nickname)) {
+            throw new CustomException(ALREADY_USE_NICKNAME);
+        }
     }
 
     private Participant findParticipant(long userId, long groupId) {

--- a/src/test/java/com/sosim/server/event/EventRepositoryTest.java
+++ b/src/test/java/com/sosim/server/event/EventRepositoryTest.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
@@ -84,12 +83,13 @@ public class EventRepositoryTest {
 
         // when
         System.out.println("=============================");
-        eventRepository.updateNicknameAll(newNickname, preNickname, 1L);
+        eventRepository.updateNicknameAll(newNickname, preNickname, group.getId());
         em.clear();
         List<Event> events = eventRepository.findAllById(eventIdList);
 
         // then
         for (Event event : events) {
+            System.out.println("event.getNickname() = " + event.getNickname());
             assertThat(event.getNickname()).isEqualTo(newNickname);
         }
     }


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- 쿼리로 직접 탈퇴한 참가자까지 확인
- 도메인 영역 바깥에서 쿼리로 체크하는 부분 이후 리팩토링 예정


<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

-

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
