### PR TITLE
Fix : 총무 닉네임 변경 시, 탈퇴한 닉네임으로 변경 가능한 에러 수정

### DIFF
--- a/src/main/java/com/sosim/server/group/domain/entity/Group.java
+++ b/src/main/java/com/sosim/server/group/domain/entity/Group.java
@@ -132,12 +132,12 @@ public class Group extends BaseTimeEntity {
     }
 
     public boolean existThatNickname(String nickname) {
-        return getParticipantList().stream()
+        return participantList.stream()
                 .anyMatch(p -> p.isActive() && p.getNickname().equals(nickname));
     }
 
     public boolean existThatNicknameIgnoreStatus(String nickname) {
-        return getParticipantList().stream()
+        return participantList.stream()
                 .anyMatch(p -> p.getNickname().equals(nickname));
     }
 

--- a/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
+++ b/src/main/java/com/sosim/server/participant/domain/entity/Participant.java
@@ -50,13 +50,12 @@ public class Participant extends BaseTimeEntity {
         if (nickname.equals(newNickname)) {
             return;
         }
-//        if (group.existThatNickname(newNickname)) {
-//            throw new CustomException(ALREADY_USE_NICKNAME);
-//        }
-//
-//        if (group.existThatNicknameIgnoreStatus(newNickname)) {
-//            throw new CustomException(USED_NICKNAME);
-//        }
+        if (group.existThatNickname(newNickname)) {
+            throw new CustomException(ALREADY_USE_NICKNAME);
+        }
+        if (group.existThatNicknameIgnoreStatus(newNickname)) {
+            throw new CustomException(USED_NICKNAME);
+        }
         nickname = newNickname;
     }
 

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -73,9 +73,6 @@ public class ParticipantService {
         Participant participant = findParticipant(userId, groupId);
         String preNickname = participant.getNickname();
 
-        checkAlreadyUsedNickname(group, newNickname);
-        checkUsedWithdrawNickname(group, newNickname);
-
         participant.modifyNickname(group, newNickname);
 
         eventRepository.updateNicknameAll(newNickname, preNickname, groupId);


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->
- 총무 닉네임 변경 시, 탈퇴한 닉네임으로 변경 가능한 문제점

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 총무 닉네임 변경 로직에 탈퇴한 닉네임 검증 로직 추가

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->
