### PR TITLE
Refactor : Participant 의 Group 재 참가 API 추가 및 서비스 로직 수정

### DIFF
--- a/src/main/java/com/sosim/server/common/auditing/BaseTimeEntity.java
+++ b/src/main/java/com/sosim/server/common/auditing/BaseTimeEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-import static com.sosim.server.common.auditing.Status.ACTIVE;
+import static com.sosim.server.common.auditing.Status.*;
 
 @Getter
 @MappedSuperclass
@@ -30,11 +30,16 @@ public class BaseTimeEntity {
     protected Status status;
 
     public void delete() {
-        status = Status.DELETED;
+        status = DELETED;
         deleteDate = LocalDateTime.now();
     }
 
     public boolean isActive() {
         return ACTIVE.equals(status);
+    }
+
+    public void reActive() {
+        status = ACTIVE;
+        deleteDate = null;
     }
 }

--- a/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/sosim/server/event/domain/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package com.sosim.server.event.domain.repository;
 
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.domain.entity.Situation;
 import com.sosim.server.event.domain.entity.Event;
 import com.sosim.server.group.domain.entity.Group;
@@ -66,7 +67,8 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
     @Modifying
     @Query("UPDATE Event e SET " +
-            "e.status = 'LOCK' " +
-            "WHERE e.nickname = :nickname AND e.group = :group")
-    void lockEvent(@Param("nickname") String nickname, @Param("group") Group group);
+            "e.status = :status " +
+            "WHERE e.user.id = :userId " +
+            "AND e.group.id = :groupId")
+    void updateEventStatus(@Param("userId") long userId, @Param("groupId") long groupId, @Param("status") Status statuss);
 }

--- a/src/main/java/com/sosim/server/participant/controller/ParticipantController.java
+++ b/src/main/java/com/sosim/server/participant/controller/ParticipantController.java
@@ -50,6 +50,13 @@ public class ParticipantController {
         return new ResponseEntity<>(Response.create(INTO_GROUP, null), INTO_GROUP.getHttpStatus());
     }
 
+    @PutMapping("/participant")
+    public ResponseEntity<?> reActiveParticipant(@AuthUserId long userId, @PathVariable long groupId) {
+        participantService.reActiveParticipant(userId, groupId);
+
+        return new ResponseEntity<>(Response.create(INTO_GROUP, null), INTO_GROUP.getHttpStatus());
+    }
+
     @DeleteMapping("/participant")
     public ResponseEntity<?> withdrawGroup(@AuthUserId long userId, @PathVariable long groupId) {
         participantService.deleteParticipant(userId, groupId);

--- a/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
@@ -13,9 +13,7 @@ import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
-    @Query("select p from Participant p where p.user.id = :userId " +
-            "and p.group.id = :groupId and p.status = 'ACTIVE'")
-    Optional<Participant> findByUserIdAndGroupId(@Param("userId") Long userId, @Param("groupId") Long groupId);
+    Optional<Participant> findByUserIdAndGroupIdAndStatus(long userId, long groupId, Status status);
 
     @Query("select p from Participant p where p.nickname = :nickname " +
            "and p.group.id = :groupId")

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -60,7 +60,7 @@ public class ParticipantService {
     @Transactional
     public void deleteParticipant(long userId, long groupId) {
         Group group = findGroupWithParticipants(groupId);
-        Participant participant = findParticipant(userId, groupId);
+        Participant participant = findActiveParticipant(userId, groupId);
 
         participant.withdrawGroup(group);
         eventRepository.lockEvent(participant.getNickname(), group);
@@ -70,7 +70,7 @@ public class ParticipantService {
     @Transactional
     public void modifyNickname(long userId, long groupId, String newNickname) {
         Group group = findGroupWithParticipantsIgnoreStatus(groupId);
-        Participant participant = findParticipant(userId, groupId);
+        Participant participant = findActiveParticipant(userId, groupId);
         String preNickname = participant.getNickname();
 
         participant.modifyNickname(group, newNickname);
@@ -81,7 +81,7 @@ public class ParticipantService {
 
     @Transactional(readOnly = true)
     public GetNicknameResponse getMyNickname(long userId, long groupId) {
-        Participant participant = findParticipant(userId, groupId);
+        Participant participant = findActiveParticipant(userId, groupId);
 
         return GetNicknameResponse.toDto(participant);
     }
@@ -106,8 +106,8 @@ public class ParticipantService {
         }
     }
 
-    private Participant findParticipant(long userId, long groupId) {
-        return participantRepository.findByUserIdAndGroupId(userId, groupId)
+    private Participant findActiveParticipant(long userId, long groupId) {
+        return participantRepository.findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT));
     }
 

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -64,7 +64,7 @@ public class ParticipantService {
         Participant participant = findActiveParticipant(userId, groupId);
 
         participant.withdrawGroup(group);
-        eventRepository.lockEvent(participant.getNickname(), group);
+        eventRepository.updateEventStatus(userId, groupId, Status.LOCK);
     }
 
     @Transactional
@@ -97,6 +97,7 @@ public class ParticipantService {
     public void reActiveParticipant(long userId, long groupId) {
         Participant participant = findDeletedParticipant(userId, groupId);
         participant.reActive();
+        eventRepository.updateEventStatus(userId, groupId, Status.ACTIVE);
     }
 
     private void checkUsedWithdrawNickname(Group group, String nickname) {

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -94,6 +94,11 @@ public class ParticipantService {
         return NicknameSearchResponse.toDto(participantList);
     }
 
+    public void reActiveParticipant(long userId, long groupId) {
+        Participant participant = findDeletedParticipant(userId, groupId);
+        participant.reActive();
+    }
+
     private void checkUsedWithdrawNickname(Group group, String nickname) {
         if (participantRepository.existsByGroupAndNickname(group, nickname)) {
             throw new CustomException(USED_NICKNAME);
@@ -107,6 +112,11 @@ public class ParticipantService {
     }
 
     private Participant findActiveParticipant(long userId, long groupId) {
+        return participantRepository.findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT));
+    }
+    
+    private Participant findDeletedParticipant(long userId, long groupId) {
         return participantRepository.findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_PARTICIPANT));
     }
@@ -179,5 +189,4 @@ public class ParticipantService {
         return groupRepository.findById(groupId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
-
 }

--- a/src/main/java/com/sosim/server/participant/service/ParticipantService.java
+++ b/src/main/java/com/sosim/server/participant/service/ParticipantService.java
@@ -1,6 +1,7 @@
 package com.sosim.server.participant.service;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
@@ -64,7 +65,6 @@ public class ParticipantService {
 
         participant.withdrawGroup(group);
         eventRepository.lockEvent(participant.getNickname(), group);
-        notificationUtil.lockNotification(participant.getNickname(), groupId);
     }
 
     @Transactional

--- a/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
+++ b/src/test/java/com/sosim/server/participant/ParticipantServiceTest.java
@@ -1,6 +1,7 @@
 package com.sosim.server.participant;
 
 import com.sosim.server.common.advice.exception.CustomException;
+import com.sosim.server.common.auditing.Status;
 import com.sosim.server.event.domain.repository.EventRepository;
 import com.sosim.server.group.domain.entity.Group;
 import com.sosim.server.group.domain.repository.GroupRepository;
@@ -259,7 +260,7 @@ class ParticipantServiceTest {
         group.getParticipantList().add(makeParticipant(2L, userId + 1, "닉네임" + 1));
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
-        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         participantService.deleteParticipant(userId, groupId);
@@ -278,7 +279,7 @@ class ParticipantServiceTest {
         group.getParticipantList().add(participant);
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
-        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         participantService.deleteParticipant(userId, groupId);
@@ -310,7 +311,7 @@ class ParticipantServiceTest {
         Group group = makeGroup();
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipants(groupId);
-        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->
@@ -331,7 +332,7 @@ class ParticipantServiceTest {
         String newNickname = "새닉네임";
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
-        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
         doNothing().when(eventRepository).updateNicknameAll(newNickname, participant.getNickname(), groupId);
 
         //when
@@ -365,7 +366,7 @@ class ParticipantServiceTest {
         Group group = makeGroup();
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
-        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->
@@ -387,7 +388,7 @@ class ParticipantServiceTest {
         group.getParticipantList().add(participant2);
 
         doReturn(Optional.of(group)).when(groupRepository).findByIdWithParticipantsIgnoreStatus(groupId);
-        doReturn(Optional.of(participant1)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.of(participant1)).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->
@@ -404,7 +405,7 @@ class ParticipantServiceTest {
         String nickname = "닉네임";
         Participant participant = makeParticipant(1L, userId, nickname);
 
-        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.of(participant)).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         GetNicknameResponse response = participantService.getMyNickname(userId, groupId);
@@ -418,7 +419,7 @@ class ParticipantServiceTest {
     @Test
     void get_my_nickname_no_group_or_participant() {
         //given
-        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupId(userId, groupId);
+        doReturn(Optional.empty()).when(participantRepository).findByUserIdAndGroupIdAndStatus(userId, groupId, Status.ACTIVE);
 
         //when
         CustomException e = assertThrows(CustomException.class, () ->


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `Group` 참가 시, 이전 `Participant` 정보 활용으로 기획 변경
- `Group` 재 참가 API 추가 필요

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `User` 정보와 `Group` 정보를 바탕으로 이전 정보를 조회
- `Status` 정보를 다시 `ACTIVE`로 수정
- `LOCK` 처리 된 `Event` 다시 `ACTIVE`로 수정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

