### PR TITLE
Feat : Group 초대장을 위한 API 추가

### DIFF
--- a/src/main/java/com/sosim/server/config/SecurityConfig.java
+++ b/src/main/java/com/sosim/server/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
         // 요청에 대한 권한 체크 파트
         http
                 .authorizeRequests()
-                .antMatchers(HttpMethod.GET, "/api/group/{groupId}").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/group/{groupId}/invitation").permitAll()
                 .antMatchers("/api/**").authenticated()
                 .antMatchers("/**").permitAll();
 

--- a/src/main/java/com/sosim/server/group/controller/GroupController.java
+++ b/src/main/java/com/sosim/server/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package com.sosim.server.group.controller;
 
 import com.sosim.server.common.resolver.AuthUserId;
 import com.sosim.server.common.response.Response;
+import com.sosim.server.group.dto.response.GroupInvitationResponse;
 import com.sosim.server.group.service.GroupService;
 import com.sosim.server.group.dto.request.CreateGroupRequest;
 import com.sosim.server.group.dto.request.ModifyGroupRequest;
@@ -31,7 +32,7 @@ public class GroupController {
     }
 
     @GetMapping("/group/{groupId}")
-    public ResponseEntity<?> getGroup(@AuthUserId(required = false) long userId, @PathVariable long groupId) {
+    public ResponseEntity<?> getGroup(@AuthUserId long userId, @PathVariable long groupId) {
         GetGroupResponse getGroupResponse = groupService.getGroup(userId, groupId);
 
         return new ResponseEntity<>(Response.create(GET_GROUP, getGroupResponse), GET_GROUP.getHttpStatus());
@@ -68,4 +69,10 @@ public class GroupController {
         return new ResponseEntity<>(Response.create(GET_MY_GROUPS, myGroups), GET_MY_GROUPS.getHttpStatus());
     }
 
+    @GetMapping("group/{groupId}/invitation")
+    public ResponseEntity<?> getGroupForInvitation(@AuthUserId(required = false) long userId, @PathVariable long groupId) {
+        GroupInvitationResponse groupForInvitation = groupService.getGroupForInvitation(userId, groupId);
+
+        return new ResponseEntity<>(Response.create(GET_GROUP, groupForInvitation), GET_GROUP.getHttpStatus());
+    }
 }

--- a/src/main/java/com/sosim/server/group/dto/response/GetGroupResponse.java
+++ b/src/main/java/com/sosim/server/group/dto/response/GetGroupResponse.java
@@ -21,8 +21,6 @@ public class GetGroupResponse {
     @JsonProperty("isAdmin")
     private boolean admin;
 
-    private int size;
-
     @JsonProperty("isInto")
     private boolean into;
 
@@ -34,11 +32,10 @@ public class GetGroupResponse {
         this.groupType = groupType;
         this.adminNickname = adminNickname;
         this.admin = admin;
-        this.size = size;
         this.into = into;
     }
 
-    public static GetGroupResponse toDto(Group group, boolean admin, int size, boolean into) {
+    public static GetGroupResponse toDto(Group group, boolean admin, boolean into) {
         return GetGroupResponse.builder()
                 .id(group.getId())
                 .title(group.getTitle())
@@ -46,7 +43,6 @@ public class GetGroupResponse {
                 .groupType(group.getGroupType())
                 .adminNickname(group.getAdminParticipant().getNickname())
                 .admin(admin)
-                .size(size)
                 .into(into)
                 .build();
     }

--- a/src/main/java/com/sosim/server/group/dto/response/GroupInvitationResponse.java
+++ b/src/main/java/com/sosim/server/group/dto/response/GroupInvitationResponse.java
@@ -1,0 +1,32 @@
+package com.sosim.server.group.dto.response;
+
+import com.sosim.server.group.domain.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupInvitationResponse {
+    private long groupId;
+
+    private String title;
+
+    private String coverColor;
+
+    private boolean isInto;
+
+    private boolean isWithdraw;
+
+    private String nickname;
+
+    public static GroupInvitationResponse toDto(Group group, boolean isInto, boolean isWithdraw, String nickname) {
+        return GroupInvitationResponse.builder()
+                .groupId(group.getId())
+                .title(group.getTitle())
+                .coverColor(group.getCoverColor())
+                .isInto(isInto)
+                .isWithdraw(isWithdraw)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -8,10 +8,7 @@ import com.sosim.server.group.domain.util.MyGroupPaginationUtil;
 import com.sosim.server.group.dto.MyGroupPageDto;
 import com.sosim.server.group.dto.request.CreateGroupRequest;
 import com.sosim.server.group.dto.request.ModifyGroupRequest;
-import com.sosim.server.group.dto.response.GetGroupResponse;
-import com.sosim.server.group.dto.response.GroupIdResponse;
-import com.sosim.server.group.dto.response.MyGroupDto;
-import com.sosim.server.group.dto.response.MyGroupsResponse;
+import com.sosim.server.group.dto.response.*;
 import com.sosim.server.notification.util.NotificationUtil;
 import com.sosim.server.participant.domain.entity.Participant;
 import com.sosim.server.participant.domain.repository.ParticipantRepository;
@@ -24,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.sosim.server.common.response.ResponseCode.NOT_FOUND_GROUP;
@@ -94,6 +92,15 @@ public class GroupService {
         return MyGroupsResponse.toResponseDto(myGroups.hasNext(), myGroups.getContent());
     }
 
+    @Transactional(readOnly = true)
+    public GroupInvitationResponse getGroupForInvitation(long userId, long groupId) {
+        Group group = findGroup(groupId);
+        Optional<Participant> participant = participantRepository.findByUserIdAndGroupId(userId, groupId);
+        boolean isInto = group.hasParticipant(userId);
+
+        return GroupInvitationResponse.toDto(group, isInto, participant.isPresent(), participant.map(Participant::getNickname).orElse(null));
+    }
+
     private void changeAdminNickname(Group group, String newNickname) {
         Participant admin = group.getAdminParticipant();
         String preNickname = admin.getNickname();
@@ -130,5 +137,4 @@ public class GroupService {
         return groupRepository.findByIdWithParticipantsIgnoreStatus(groupId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
     }
-
 }

--- a/src/main/java/com/sosim/server/group/service/GroupService.java
+++ b/src/main/java/com/sosim/server/group/service/GroupService.java
@@ -55,8 +55,7 @@ public class GroupService {
 
         boolean isAdmin = group.isAdminUser(userId);
         boolean isInto = group.hasParticipant(userId);
-        int numberOfParticipants = group.getNumberOfParticipants();
-        return GetGroupResponse.toDto(group, isAdmin, numberOfParticipants, isInto);
+        return GetGroupResponse.toDto(group, isAdmin, isInto);
     }
 
     @Transactional

--- a/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/sosim/server/participant/domain/repository/ParticipantRepository.java
@@ -13,9 +13,7 @@ import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
-    @Query("select p from Participant p where p.user.id = :userId " +
-            "and p.group.id = :groupId and p.status = 'ACTIVE'")
-    Optional<Participant> findByUserIdAndGroupId(@Param("userId") Long userId, @Param("groupId") Long groupId);
+    Optional<Participant> findByUserIdAndGroupId(long userId, long groupId);
 
     @Query("select p from Participant p where p.nickname = :nickname " +
            "and p.group.id = :groupId")

--- a/src/test/java/com/sosim/server/group/GroupControllerTest.java
+++ b/src/test/java/com/sosim/server/group/GroupControllerTest.java
@@ -17,6 +17,7 @@ import com.sosim.server.security.WithMockCustomUser;
 import com.sosim.server.security.WithMockCustomUserSecurityContextFactory;
 import com.sosim.server.user.domain.entity.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -247,6 +248,7 @@ class GroupControllerTest {
                 .andExpect(jsonPath("$.content").isEmpty());
     }
 
+    @Disabled
     @DisplayName("그룹 조회 / 인증 없이 조회하는 경우")
     @Test
     void get_group_no_userId() throws Exception {

--- a/src/test/java/com/sosim/server/group/GroupServiceTest.java
+++ b/src/test/java/com/sosim/server/group/GroupServiceTest.java
@@ -127,7 +127,6 @@ class GroupServiceTest {
         assertThat(response.getGroupId()).isEqualTo(groupId);
         assertThat(response.getTitle()).isEqualTo(title);
         assertThat(response.getAdminNickname()).isEqualTo(admin.getNickname());
-        assertThat(response.getSize()).isEqualTo(1);
         assertThat(response.isInto()).isTrue();
     }
 


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

- `Group` 초대장을 위한 API 추가 필요
- `GetGroup`, `GetGroupForInvitation` 분리

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- `Participant` 정보의 존재 여부와 함께 초대장에 필요한 필드 값 매핑 객체 추가
- 기존의 `GetGroup`과 분리
- `Authorization` URI 매핑 수정

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->
